### PR TITLE
SessionAlarmService fix for Android Oreo

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,15 +36,18 @@
             android:name=".ui.activity.SessionDetailActivity"
             android:configChanges="orientation|screenSize"/>
 
-        <receiver android:name=".receiver.SessionAlarmReceiver">
+        <receiver
+            android:name=".receiver.SessionAlarmReceiver"
+            android:exported="false">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>
         </receiver>
 
         <service
             android:name=".service.SessionAlarmService"
-            android:exported="false" />
+            android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE"/>
 
         <service
             android:name=".service.MyFirebaseMessagingService">

--- a/app/src/main/java/fr/paug/androidmakers/receiver/SessionAlarmReceiver.java
+++ b/app/src/main/java/fr/paug/androidmakers/receiver/SessionAlarmReceiver.java
@@ -3,7 +3,6 @@ package fr.paug.androidmakers.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.content.ContextCompat;
 
 import fr.paug.androidmakers.service.SessionAlarmService;
 
@@ -12,10 +11,17 @@ public class SessionAlarmReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        Intent scheduleIntent = new Intent(
-                SessionAlarmService.ACTION_SCHEDULE_ALL_STARRED_BLOCKS,
-                null, context, SessionAlarmService.class);
-        ContextCompat.startForegroundService(context, scheduleIntent);
+        final String action = intent.getAction();
+
+        if (SessionAlarmService.ACTION_NOTIFY_SESSION.equals(action)) {
+            Intent scheduleIntent = new Intent(SessionAlarmService.ACTION_NOTIFY_SESSION)
+                    .setData(intent.getData())
+                    .putExtras(intent);
+            SessionAlarmService.enqueueWork(context, scheduleIntent);
+        } else if (Intent.ACTION_BOOT_COMPLETED.equals(action)) {
+            Intent scheduleIntent = new Intent(SessionAlarmService.ACTION_SCHEDULE_ALL_STARRED_BLOCKS);
+            SessionAlarmService.enqueueWork(context, scheduleIntent);
+        }
     }
 
 }

--- a/app/src/main/java/fr/paug/androidmakers/service/SessionAlarmService.java
+++ b/app/src/main/java/fr/paug/androidmakers/service/SessionAlarmService.java
@@ -1,15 +1,16 @@
 package fr.paug.androidmakers.service;
 
 import android.app.AlarmManager;
-import android.app.IntentService;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.DateUtils;
 import android.util.Log;
@@ -18,17 +19,23 @@ import java.util.Date;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
 
 import fr.paug.androidmakers.R;
 import fr.paug.androidmakers.manager.AgendaRepository;
 import fr.paug.androidmakers.model.Room;
 import fr.paug.androidmakers.model.ScheduleSlot;
 import fr.paug.androidmakers.model.Session;
+import fr.paug.androidmakers.receiver.SessionAlarmReceiver;
 import fr.paug.androidmakers.ui.activity.MainActivity;
 import fr.paug.androidmakers.util.SessionSelector;
 
-public class SessionAlarmService extends IntentService {
+public class SessionAlarmService extends JobIntentService {
 
+    /**
+     * Unique job ID for this service.
+     */
+    private static final int JOB_ID = 1000;
     private static final String TAG = "sessionAlarm";
 
     public static final String ACTION_NOTIFY_SESSION = "NOTIFY_SESSION";
@@ -51,17 +58,15 @@ public class SessionAlarmService extends IntentService {
 
     private static final long UNDEFINED_VALUE = -1;
 
-    public SessionAlarmService() {
-        super("SessionAlarmService");
+    /**
+     * Convenience method for enqueuing work in to this service.
+     */
+    public static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, SessionAlarmService.class, JOB_ID, work);
     }
 
     @Override
-    public void onCreate() {
-        super.onCreate();
-    }
-
-    @Override
-    protected void onHandleIntent(Intent intent) {
+    protected void onHandleWork(Intent intent) {
         final String action = intent.getAction();
         logDebug("Session alarm : " + action);
 
@@ -98,6 +103,7 @@ public class SessionAlarmService extends IntentService {
 
     void scheduleAllStarredSessions() {
         logDebug("scheduleAllStarredSessions");
+        final CountDownLatch latch = new CountDownLatch(1);
         // need to be sure that the AgendaRepository is loaded in order to schedule all starred sessions
         final Runnable runnable = new Runnable() {
             @Override
@@ -122,9 +128,14 @@ public class SessionAlarmService extends IntentService {
                                 scheduleSlot.sessionId, false);
                     }
                 }
+                latch.countDown();
             }
         };
         AgendaRepository.getInstance().load(new AgendaLoadListener(runnable));
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+        }
     }
 
     /**
@@ -180,9 +191,9 @@ public class SessionAlarmService extends IntentService {
 
         final Intent notificationIntent = new Intent(
                 ACTION_NOTIFY_SESSION,
-                null,
+                Uri.parse(String.valueOf(sessionId)),
                 this,
-                SessionAlarmService.class);
+                SessionAlarmReceiver.class);
         notificationIntent.putExtra(EXTRA_SESSION_START, sessionStart);
         logDebug("-> Intent extra: session start " + sessionStart);
         notificationIntent.putExtra(EXTRA_SESSION_END, sessionEnd);
@@ -191,8 +202,7 @@ public class SessionAlarmService extends IntentService {
         notificationIntent.putExtra(EXTRA_NOTIFICATION_TITLE, sessionToNotify.title);
         notificationIntent.putExtra(EXTRA_NOTIFICATION_CONTENT, roomName + sessionDate);
 
-        PendingIntent pendingIntent = PendingIntent.getService(this, sessionId, notificationIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(this, sessionId, notificationIntent, 0);
 
         final AlarmManager alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
         // Schedule an alarm to be fired to notify user of added sessions are about to begin.
@@ -209,11 +219,10 @@ public class SessionAlarmService extends IntentService {
         final AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
         final Intent notifIntent = new Intent(
                 ACTION_NOTIFY_SESSION,
-                null,
+                Uri.parse(String.valueOf(sessionId)),
                 this,
-                SessionAlarmService.class);
-        PendingIntent pi = PendingIntent.getService(this, sessionId, notifIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+                SessionAlarmReceiver.class);
+        PendingIntent pi = PendingIntent.getBroadcast(this, sessionId, notifIntent, 0);
 
         am.cancel(pi);
     }

--- a/app/src/main/java/fr/paug/androidmakers/service/SessionAlarmService.java
+++ b/app/src/main/java/fr/paug/androidmakers/service/SessionAlarmService.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.v4.app.AlarmManagerCompat;
 import android.support.v4.app.JobIntentService;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.DateUtils;
@@ -207,7 +208,7 @@ public class SessionAlarmService extends JobIntentService {
         final AlarmManager alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
         // Schedule an alarm to be fired to notify user of added sessions are about to begin.
         logDebug("-> Scheduling RTC_WAKEUP alarm at " + alarmTime);
-        alarmManager.set(AlarmManager.RTC_WAKEUP, alarmTime, pendingIntent);
+        AlarmManagerCompat.setExact(alarmManager, AlarmManager.RTC_WAKEUP, alarmTime, pendingIntent);
     }
 
     /**

--- a/app/src/main/java/fr/paug/androidmakers/ui/fragment/AgendaFragment.java
+++ b/app/src/main/java/fr/paug/androidmakers/ui/fragment/AgendaFragment.java
@@ -236,10 +236,8 @@ public class AgendaFragment extends Fragment {
             if (fragment != null) {
                 // reschedule all starred blocks in case one session start or stop time has changed
                 final Context ctx = fragment.getContext();
-                Intent scheduleIntent = new Intent(
-                        SessionAlarmService.ACTION_SCHEDULE_ALL_STARRED_BLOCKS,
-                        null, ctx, SessionAlarmService.class);
-                ctx.startService(scheduleIntent);
+                Intent scheduleIntent = new Intent(SessionAlarmService.ACTION_SCHEDULE_ALL_STARRED_BLOCKS);
+                SessionAlarmService.enqueueWork(ctx, scheduleIntent);
             }
         }
     }

--- a/app/src/main/java/fr/paug/androidmakers/util/ScheduleSessionHelper.java
+++ b/app/src/main/java/fr/paug/androidmakers/util/ScheduleSessionHelper.java
@@ -22,24 +22,20 @@ public class ScheduleSessionHelper {
         Log.d("Schedule session", "Scheduling notification for session " + sessionId);
         Toast.makeText(context, R.string.session_selected, Toast.LENGTH_SHORT).show();
 
-        final Intent scheduleIntent = new Intent(
-                SessionAlarmService.ACTION_SCHEDULE_STARRED_BLOCK,
-                null, context, SessionAlarmService.class);
+        final Intent scheduleIntent = new Intent(SessionAlarmService.ACTION_SCHEDULE_STARRED_BLOCK);
         scheduleIntent.putExtra(SessionAlarmService.EXTRA_SESSION_START, sessionStartDateInMillis);
         scheduleIntent.putExtra(SessionAlarmService.EXTRA_SESSION_END, sessionEndDateInMillis);
         scheduleIntent.putExtra(SessionAlarmService.EXTRA_SESSION_ID, sessionId);
-        context.startService(scheduleIntent);
+        SessionAlarmService.enqueueWork(context, scheduleIntent);
     }
 
     public static void unScheduleSession(Context context, int sessionId) {
         Log.d("Schedule session", "Unscheduling notification for session " + sessionId);
         Toast.makeText(context, R.string.session_deselected, Toast.LENGTH_SHORT).show();
 
-        final Intent scheduleIntent = new Intent(
-                SessionAlarmService.ACTION_UNSCHEDULE_UNSTARRED_BLOCK,
-                null, context, SessionAlarmService.class);
+        final Intent scheduleIntent = new Intent(SessionAlarmService.ACTION_UNSCHEDULE_UNSTARRED_BLOCK);
         scheduleIntent.putExtra(SessionAlarmService.EXTRA_SESSION_ID, sessionId);
-        context.startService(scheduleIntent);
+        SessionAlarmService.enqueueWork(context, scheduleIntent);
     }
     //endregion
 


### PR DESCRIPTION
SessionAlarmService currently crashes after Oreo devices boot because background services may not be started when the app is not in the foreground.
The proper fix is to reimplement SessionAlarmService as a JobIntentService which is a remplacement for IntentService.
AlarmManager intents are now also routed through the BroadcastReceiver so the job can be properly configured and launched.

Additionally, this pull request also uses AlarmManager.setExact() for more accurate notifications on API 19+ devices.