### PR TITLE
Use schedule as single source of truth

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ android {
         versionCode versionMajor * 1000 + versionMinor * 100 + versionPatch * 10
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
 
         buildConfigField "String", "YOUTUBE_API_KEY", "\"" + System.getProperty("androidMakersYouTubeApiKey", "dummyAPIKey") + "\""
     }
@@ -77,6 +78,8 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
+
+    implementation 'com.android.support:multidex:1.0.3'
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/app/src/main/java/fr/paug/androidmakers/manager/AndroidMakersStore.kt
+++ b/app/src/main/java/fr/paug/androidmakers/manager/AndroidMakersStore.kt
@@ -76,17 +76,17 @@ class AndroidMakersStore {
 
     fun getSlots(callback: (List<ScheduleSlotKt>) -> Unit) {
         FirebaseFirestore.getInstance()
-                .collection("schedule").document("2019-04-23")
+                .collection("schedule").document(DAY1)
                 .get()
                 .addOnSuccessListener { result1 ->
                     FirebaseFirestore.getInstance()
-                            .collection("schedule").document("2019-04-24")
+                            .collection("schedule").document(DAY2)
                             .get()
                             .addOnSuccessListener { result2 ->
                                 try {
                                     convertResults(mapOf(
-                                            "2019-04-23" to result1,
-                                            "2019-04-24" to result2
+                                            DAY1 to result1,
+                                            DAY2 to result2
                                     ), callback)
                                 } catch (e: Exception) {
                                     Log.w(TAG, "Cannot convert from schedule", e)
@@ -104,7 +104,6 @@ class AndroidMakersStore {
     private fun convertResults(results: Map<String, DocumentSnapshot>, callback: (List<ScheduleSlotKt>) -> Unit) {
         val list = mutableListOf<ScheduleSlotKt>()
         for (result in results) {
-
             val day = result.value.data!!
             val timeSlots = day.getAsListOfMaps("timeslots")
 
@@ -131,9 +130,7 @@ class AndroidMakersStore {
                                 startDate = getDate(result.key, startTime),
                                 endDate = getDate(result.key, endTime),
                                 roomId = roomId,
-                                sessionId = sessionId
-                                )
-                        )
+                                sessionId = sessionId))
                     }
                 }
             }
@@ -144,7 +141,6 @@ class AndroidMakersStore {
 
 
     /**
-     *
      * @param date the date as YYYY-MM-DD
      * @param time the time as HH:mm
      * @return a ISO86-01 String
@@ -153,7 +149,7 @@ class AndroidMakersStore {
         val d = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).parse("$date $time")
 
         val tz = TimeZone.getTimeZone("UTC")
-        val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ",Locale.US)
+        val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
         df.timeZone = tz
         return df.format(d)
     }
@@ -225,6 +221,8 @@ class AndroidMakersStore {
     }
 
     companion object {
+        private const val DAY1 = "2019-04-23"
+        private const val DAY2 = "2019-04-24"
         private const val TAG = "Firestore"
     }
 }


### PR DESCRIPTION
convert from the website data directly in the app. This way, slight changes to the schedule won't require any manual intervention to work on the app automagically

PS: I had to enable multidex to work on non-minified (debug) versions of the app. I'm okay to remove it if needed.