### PR TITLE
[Do Not Merge] Adding LeakCanary 2 snapshot

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ android {
     defaultConfig {
         applicationId "fr.paug.androidmakers"
         minSdkVersion 15
+        multiDexEnabled true
         targetSdkVersion 28
         versionCode versionMajor * 1000 + versionMinor * 100 + versionPatch * 10
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
@@ -110,6 +111,8 @@ dependencies {
 
     // For Video preview
     implementation files('libs/YouTubeAndroidPlayerApi.jar')
+
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0-alpha-1-SNAPSHOT'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
     }
 }
 


### PR DESCRIPTION
* *Do not merge* as this depends on a snapshot (releasing coming soon, if you do want it)
* LeakCanary is typically installed on debug builds. To run `./gradlew app:installPreprodDebug` I had to enable Multidex.
* To also build I had to create a `google-services.json` file, not sure how to avoid that.
* I did find a leak. To repro: start the app, go to Venue tab, then press Home (LeakCanary kicks in on app background).

I'm going to file to Android X as this does seem to be library bug. In a nutshell AgendaFragment overrides onCreateOptionsMenu and adds a menu item with a listener. When we move to Venue the AgendaFragment is destroyed, onDestroyOptionsMenu() is called on it, the menu item is hidden however a ActionMenuItemView holding on to it, itself held by a ActionMenuPresenter.mScrapActionButtonView, itself held by ToolbarWidgetWrapper.mActionMenuPresenter . Since that action view is not displayed anymore, it shouldn't be held in memory.

Here's the leaktrace:

```
 ┬
 ├─ android.app.ActivityThread
 │    Leaking: NO (it's a GC root)
 │    ↓ ActivityThread.mActivities
 ├─ android.util.ArrayMap
 │    Leaking: NO (Object[]↓ is not leaking)
 │    ↓ ArrayMap.mArray
 ├─ java.lang.Object[]
 │    Leaking: NO (ActivityThread$ActivityClientRecord↓ is not leaking)
 │    ↓ array Object[].[1]
 ├─ android.app.ActivityThread$ActivityClientRecord
 │    Leaking: NO (MainActivity↓ is not leaking)
 │    ↓ ActivityThread$ActivityClientRecord.activity
 ├─ fr.paug.androidmakers.ui.activity.MainActivity
 │    Leaking: NO (Activity#mDestroyed is not true)
 │    ↓ MainActivity.mDelegate
 │                   ~~~~~~~~~
 ├─ androidx.appcompat.app.AppCompatDelegateImpl
 │    Leaking: UNKNOWN
 │    ↓ AppCompatDelegateImpl.mActionBar
 │                            ~~~~~~~~~~
 ├─ androidx.appcompat.app.WindowDecorActionBar
 │    Leaking: UNKNOWN
 │    ↓ WindowDecorActionBar.mDecorToolbar
 │                           ~~~~~~~~~~~~~
 ├─ androidx.appcompat.widget.ToolbarWidgetWrapper
 │    Leaking: UNKNOWN
 │    ↓ ToolbarWidgetWrapper.mActionMenuPresenter
 │                           ~~~~~~~~~~~~~~~~~~~~
 ├─ androidx.appcompat.widget.ActionMenuPresenter
 │    Leaking: UNKNOWN
 │    ↓ ActionMenuPresenter.mScrapActionButtonView
 │                          ~~~~~~~~~~~~~~~~~~~~~~
 ├─ androidx.appcompat.view.menu.ActionMenuItemView
 │    Leaking: UNKNOWN
 │    ↓ ActionMenuItemView.mItemData
 │                         ~~~~~~~~~
 ├─ androidx.appcompat.view.menu.MenuItemImpl
 │    Leaking: UNKNOWN
 │    ↓ MenuItemImpl.mClickListener
 │                   ~~~~~~~~~~~~~~
 ├─ fr.paug.androidmakers.ui.fragment.AgendaFragment$onCreateOptionsMenu$1
 │    Leaking: UNKNOWN
 │    ↓ AgendaFragment$onCreateOptionsMenu$1.this$0 (anonymous implementation of android.view.MenuItem$OnMenuItemClickListener)
 │                                           ~~~~~~
 ├─ fr.paug.androidmakers.ui.fragment.AgendaFragment
 │    Leaking: YES (Fragment#mFragmentManager is null)
 │    ↓ AgendaFragment.mDrawerLayout
 ╰→ androidx.drawerlayout.widget.DrawerLayout
 ​     Leaking: YES (RefWatcher was watching this)
 ```