### PR TITLE
Fix Options Menu leak in AgendaFragment

### DIFF
--- a/app/src/main/java/fr/paug/androidmakers/ui/fragment/AgendaFragment.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/fragment/AgendaFragment.kt
@@ -334,20 +334,24 @@ class AgendaFragment : Fragment() {
         mFiltersView?.addView(view, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater?) {
         super.onCreateOptionsMenu(menu, inflater)
 
-        val menuItem = menu?.add(activity!!.getString(R.string.filter))
-        menuItem?.setIcon(R.drawable.ic_filter_list_white_24dp)
-        menuItem?.setShowAsAction(SHOW_AS_ACTION_ALWAYS)
-        menuItem?.setOnMenuItemClickListener {
+        val menuItem = menu.add(0, R.id.filter, 0, activity!!.getString(R.string.filter))!!
+        menuItem.setIcon(R.drawable.ic_filter_list_white_24dp)
+        menuItem.setShowAsAction(SHOW_AS_ACTION_ALWAYS)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == R.id.filter) {
             if (mDrawerLayout!!.isDrawerOpen(GravityCompat.END)) {
                 mDrawerLayout!!.closeDrawer(GravityCompat.END)
             } else {
                 mDrawerLayout!!.openDrawer(GravityCompat.END)
             }
-            true
+            return true
         }
+        return false
     }
     //endregion
 

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <item name="filter" type="id"/>
+
+</resources>


### PR DESCRIPTION
See https://github.com/paug/AndroidMakersApp/pull/59 for context.

Replacing the listener callback with onOptionsItemSelected makes the leak of the listener go away, even though the menu item itself is still leaking.