### PR TITLE
Fix toast leak

### DIFF
--- a/app/src/main/java/fr/paug/androidmakers/ui/activity/BaseActivity.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/activity/BaseActivity.kt
@@ -2,6 +2,7 @@ package fr.paug.androidmakers.ui.activity
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import fr.paug.androidmakers.util.ScheduleSessionHelper
 
 import fr.paug.androidmakers.util.ThemeUtils
 
@@ -12,4 +13,8 @@ abstract class BaseActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        ScheduleSessionHelper.cancelToast()
+    }
 }

--- a/app/src/main/java/fr/paug/androidmakers/util/ScheduleSessionHelper.kt
+++ b/app/src/main/java/fr/paug/androidmakers/util/ScheduleSessionHelper.kt
@@ -45,6 +45,11 @@ object ScheduleSessionHelper {
         scheduleIntent.putExtra(SessionAlarmService.EXTRA_SESSION_ID, sessionId)
         SessionAlarmService.enqueueWork(context, scheduleIntent)
     }
+
+    fun cancelToast() {
+        toast?.cancel()
+        toast = null
+    }
     //endregion
 
 }


### PR DESCRIPTION
ScheduleSessionHelper is a singleton that keeps a reference to the latest toast it showed. The toast has a reference to the context, that context can be a destroyed activity.

To reproduce: add LeakCanary, go to a session, add the session (toast shows), press back, press home.

Fix: when an activity, cancel any displayed toast.