### PR TITLE
Discard HTML information

### DIFF
--- a/app/src/main/java/fr/paug/androidmakers/ui/components/SessionDetailLayout.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/components/SessionDetailLayout.kt
@@ -3,6 +3,7 @@ package fr.paug.androidmakers.ui.components
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.text.Html
 import android.text.TextUtils
 import android.text.format.DateUtils
 import androidx.compose.animation.Crossfade
@@ -36,6 +37,7 @@ import fr.androidmakers.store.model.*
 import fr.paug.androidmakers.AndroidMakersApplication
 import fr.paug.androidmakers.R
 import fr.paug.androidmakers.ui.theme.AMColor
+import fr.paug.androidmakers.ui.util.discardHtmlTags
 import fr.paug.androidmakers.ui.util.imageUrl
 import fr.paug.androidmakers.ui.viewmodel.Lce
 import io.openfeedback.android.components.SessionFeedbackContainer
@@ -148,7 +150,7 @@ private fun SessionDetails(sessionDetails: SessionDetailState, formattedDateAndR
     )
     Text(
         modifier = Modifier.padding(top = 16.dp),
-        text = sessionDetails.session.description,
+        text = sessionDetails.session.description.discardHtmlTags(),
         style = MaterialTheme.typography.body1
     )
     ChipList(sessionDetails)

--- a/app/src/main/java/fr/paug/androidmakers/ui/components/VenueLayout.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/components/VenueLayout.kt
@@ -24,6 +24,7 @@ import coil.compose.AsyncImage
 import com.google.android.material.snackbar.Snackbar
 import fr.paug.androidmakers.R
 import fr.paug.androidmakers.ui.model.UIVenue
+import fr.paug.androidmakers.ui.util.discardHtmlTags
 import fr.paug.androidmakers.util.CustomTabUtil
 import surfaceColor2
 
@@ -62,7 +63,7 @@ fun VenueLayout(uiVenue: UIVenue) {
         uiVenue.descriptionEn
     }
     Text(
-        text = Html.fromHtml(description).toString(),
+        text = description.discardHtmlTags(),
         modifier = Modifier.padding(8.dp),
         style = MaterialTheme.typography.body1,
     )

--- a/app/src/main/java/fr/paug/androidmakers/ui/util/TextUtil.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/util/TextUtil.kt
@@ -1,0 +1,20 @@
+package fr.paug.androidmakers.ui.util
+
+import android.os.Build
+import android.text.Html
+import android.text.Html.FROM_HTML_MODE_COMPACT
+
+/**
+ * Discards HTML information from a String
+ *
+ * In order to keep the style information, we'd need something that does HTML -> AnnotatedString
+ * or Spanned -> AnnotatedString which doesn't seem to exist
+ * See https://stackoverflow.com/questions/66494838/android-compose-how-to-use-html-tags-in-a-text-view#comment117551793_66494838
+ */
+internal fun String.discardHtmlTags(): String {
+  return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+    Html.fromHtml(this, FROM_HTML_MODE_COMPACT).toString()
+  } else {
+    Html.fromHtml(this).toString()
+  }
+}


### PR DESCRIPTION
Closes https://github.com/paug/AndroidMakersApp/issues/101. 

I haven't found a way to display Html data in a composable just yet and TBH I kind of like that it's not too cluttered