### PR TITLE
Fix filters resetting when returning from session details

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("fr.androidmakers.gradle.android.application")
-    id("kotlin-parcelize")
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("fr.androidmakers.gradle.android.application")
+    id("kotlin-parcelize")
 }
 
 dependencies {

--- a/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaLayout.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaLayout.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -42,8 +41,8 @@ fun AgendaLayout(
     agendaFilterDrawerState: DrawerState,
     onSessionClick: (sessionId: String, roomId: String, startTimestamp: Long, endTimestamp: Long) -> Unit,
 ) {
-  var sessionFilters: List<SessionFilter> by rememberSaveable { mutableStateOf(listOf()) }
-  val rooms = AndroidMakersApplication.instance().store.getRooms()
+  val agendaLayoutViewModel = viewModel<AgendaLayoutViewModel>()
+  val agendaLayoutState by agendaLayoutViewModel.state.collectAsState()
 
   // XXX This is a hack to make the drawer appear from the right
   CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
@@ -53,25 +52,23 @@ fun AgendaLayout(
           // XXX Go back to left to right for the contents
           CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
             AgendaFilterDrawer(
-                rooms = rooms.collectAsState(initial = Result.success(emptyList())).value
-                    .recover { emptyList() }
-                    .getOrThrow(),
-                sessionFilters = sessionFilters,
-                onFiltersChanged = { newFilters -> sessionFilters = newFilters }
+                rooms = agendaLayoutState.rooms,
+                sessionFilters = agendaLayoutState.sessionFilters,
+                onFiltersChanged = agendaLayoutViewModel::onFiltersChanged
             )
           }
         },
         content = {
           // XXX Go back to left to right for the contents
           CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-            AgendaPagerOrLoading(sessionFilters, onSessionClick)
+            AgendaPagerOrLoading(agendaLayoutState.sessionFilters, onSessionClick)
           }
         }
     )
   }
 }
 
-class AgendaLayoutViewModel : LceViewModel<Agenda>() {
+class AgendaPagerViewModel : LceViewModel<Agenda>() {
   override fun produce(): Flow<Result<Agenda>> {
     return AndroidMakersApplication.instance().store.getAgenda()
   }
@@ -82,7 +79,7 @@ private fun AgendaPagerOrLoading(
     sessionFilters: List<SessionFilter>,
     onSessionClick: (sessionId: String, roomId: String, startTimestamp: Long, endTimestamp: Long) -> Unit,
 ) {
-  ButtonRefreshableLceLayout(viewModel<AgendaLayoutViewModel>()) {
+  ButtonRefreshableLceLayout(viewModel<AgendaPagerViewModel>()) {
     val days = agendaToDays(it)
 
     AgendaPager(
@@ -185,7 +182,7 @@ private fun FilterItem(
       modifier = Modifier
           .fillMaxWidth()
           .clickable {
-            onCheck(!checked)
+              onCheck(!checked)
           },
       verticalAlignment = Alignment.CenterVertically,
   ) {

--- a/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaLayout.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaLayout.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -41,7 +42,7 @@ fun AgendaLayout(
     agendaFilterDrawerState: DrawerState,
     onSessionClick: (sessionId: String, roomId: String, startTimestamp: Long, endTimestamp: Long) -> Unit,
 ) {
-  var sessionFilters: List<SessionFilter> by remember { mutableStateOf(listOf()) }
+  var sessionFilters: List<SessionFilter> by rememberSaveable { mutableStateOf(listOf()) }
   val rooms = AndroidMakersApplication.instance().store.getRooms()
 
   // XXX This is a hack to make the drawer appear from the right

--- a/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaLayoutViewModel.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaLayoutViewModel.kt
@@ -6,6 +6,7 @@ import fr.androidmakers.store.AndroidMakersStore
 import fr.androidmakers.store.model.Room
 import fr.paug.androidmakers.AndroidMakersApplication
 import fr.paug.androidmakers.util.SessionFilter
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -19,7 +20,8 @@ data class AgendaLayoutState(
 )
 
 class AgendaLayoutViewModel(
-  store: AndroidMakersStore = AndroidMakersApplication.instance().store
+  store: AndroidMakersStore = AndroidMakersApplication.instance().store,
+  scope: ViewModel.() -> CoroutineScope = { viewModelScope }
 ) : ViewModel() {
   private val sessionFilters = MutableStateFlow(emptyList<SessionFilter>())
 
@@ -27,7 +29,7 @@ class AgendaLayoutViewModel(
     store.getRooms().map { rooms -> rooms.recover { emptyList() }.getOrThrow() },
     sessionFilters,
     ::AgendaLayoutState
-  ).stateIn(viewModelScope, SharingStarted.WhileSubscribed(), AgendaLayoutState())
+  ).stateIn(scope(), SharingStarted.WhileSubscribed(), AgendaLayoutState())
 
   fun onFiltersChanged(sessionFilters: List<SessionFilter>) {
     this.sessionFilters.value = sessionFilters

--- a/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaLayoutViewModel.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaLayoutViewModel.kt
@@ -1,0 +1,35 @@
+package fr.paug.androidmakers.ui.components
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.androidmakers.store.AndroidMakersStore
+import fr.androidmakers.store.model.Room
+import fr.paug.androidmakers.AndroidMakersApplication
+import fr.paug.androidmakers.util.SessionFilter
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+data class AgendaLayoutState(
+  val rooms: List<Room> = emptyList(),
+  val sessionFilters: List<SessionFilter> = emptyList()
+)
+
+class AgendaLayoutViewModel(
+  store: AndroidMakersStore = AndroidMakersApplication.instance().store
+) : ViewModel() {
+  private val sessionFilters = MutableStateFlow(emptyList<SessionFilter>())
+
+  val state: StateFlow<AgendaLayoutState> = combine(
+    store.getRooms().map { rooms -> rooms.recover { emptyList() }.getOrThrow() },
+    sessionFilters,
+    ::AgendaLayoutState
+  ).stateIn(viewModelScope, SharingStarted.WhileSubscribed(), AgendaLayoutState())
+
+  fun onFiltersChanged(sessionFilters: List<SessionFilter>) {
+    this.sessionFilters.value = sessionFilters
+  }
+}

--- a/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaPager.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/components/AgendaPager.kt
@@ -67,7 +67,7 @@ fun AgendaPager(
         count = days.size,
         state = pagerState,
     ) { page ->
-      val viewModel = viewModel<AgendaLayoutViewModel>()
+      val viewModel = viewModel<AgendaPagerViewModel>()
       SwipeRefreshableLceLayout(viewModel = viewModel) {
         val days = agendaToDays(it)
         val items = days[page].roomSchedules.flatMap { it.scheduleSessions }

--- a/app/src/main/java/fr/paug/androidmakers/util/SessionFilter.kt
+++ b/app/src/main/java/fr/paug/androidmakers/util/SessionFilter.kt
@@ -1,10 +1,6 @@
 package fr.paug.androidmakers.util
 
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
-
-@Parcelize
-class SessionFilter(val type: FilterType, val value: String) : Parcelable {
+class SessionFilter(val type: FilterType, val value: Any) {
     enum class FilterType {
         BOOKMARK,
         LANGUAGE,

--- a/app/src/main/java/fr/paug/androidmakers/util/SessionFilter.kt
+++ b/app/src/main/java/fr/paug/androidmakers/util/SessionFilter.kt
@@ -1,6 +1,6 @@
 package fr.paug.androidmakers.util
 
-class SessionFilter(val type: FilterType, val value: Any) {
+data class SessionFilter(val type: FilterType, val value: Any) {
     enum class FilterType {
         BOOKMARK,
         LANGUAGE,

--- a/app/src/main/java/fr/paug/androidmakers/util/SessionFilter.kt
+++ b/app/src/main/java/fr/paug/androidmakers/util/SessionFilter.kt
@@ -1,6 +1,10 @@
 package fr.paug.androidmakers.util
 
-class SessionFilter(val type: FilterType, val value: Any) {
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+class SessionFilter(val type: FilterType, val value: String) : Parcelable {
     enum class FilterType {
         BOOKMARK,
         LANGUAGE,

--- a/app/src/test/java/fr/paug/androidmakers/fixtures/FakeAndroidMakersStore.kt
+++ b/app/src/test/java/fr/paug/androidmakers/fixtures/FakeAndroidMakersStore.kt
@@ -1,0 +1,62 @@
+package fr.paug.androidmakers.fixtures
+
+import fr.androidmakers.store.AndroidMakersStore
+import fr.androidmakers.store.model.Partner
+import fr.androidmakers.store.model.Room
+import fr.androidmakers.store.model.ScheduleSlot
+import fr.androidmakers.store.model.Session
+import fr.androidmakers.store.model.Speaker
+import fr.androidmakers.store.model.Venue
+import fr.androidmakers.store.model.WifiInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeAndroidMakersStore : AndroidMakersStore {
+  val roomsMutableFlow = MutableStateFlow(Result.success(emptyList<Room>()))
+
+  override fun getRooms(): Flow<Result<List<Room>>> = roomsMutableFlow
+
+  override fun getVenue(id: String): Flow<Result<Venue>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getSpeaker(id: String): Flow<Result<Speaker>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getRoom(id: String): Flow<Result<Room>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getSession(id: String): Flow<Result<Session>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getPartners(): Flow<Result<List<Partner>>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getScheduleSlots(): Flow<Result<List<ScheduleSlot>>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getSessions(): Flow<Result<List<Session>>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getSpeakers(): Flow<Result<List<Speaker>>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getWifiInfo(): Flow<Result<WifiInfo?>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getBookmarks(userId: String): Flow<Result<Set<String>>> {
+    TODO("Not yet implemented")
+  }
+
+  override suspend fun setBookmark(userId: String, sessionId: String, value: Boolean) {
+    TODO("Not yet implemented")
+  }
+}

--- a/app/src/test/java/fr/paug/androidmakers/ui/components/AgendaLayoutViewModelTest.kt
+++ b/app/src/test/java/fr/paug/androidmakers/ui/components/AgendaLayoutViewModelTest.kt
@@ -1,0 +1,72 @@
+package fr.paug.androidmakers.ui.components
+
+import fr.androidmakers.store.model.Room
+import fr.paug.androidmakers.fixtures.FakeAndroidMakersStore
+import fr.paug.androidmakers.util.SessionFilter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.lang.RuntimeException
+
+class AgendaLayoutViewModelTest {
+
+  private val fakeStore = FakeAndroidMakersStore()
+
+  private val testSubject = AgendaLayoutViewModel(
+    store = fakeStore,
+    scope = { CoroutineScope(Dispatchers.Unconfined) }
+  )
+
+  @Test
+  fun `initial state should be correct`() = runBlocking {
+    assertEquals(
+      AgendaLayoutState(
+        rooms = emptyList(),
+        sessionFilters = emptyList()
+      ),
+      testSubject.state.first()
+    )
+  }
+
+  @Test
+  fun `given non empty session filters state should be correct`() = runBlocking {
+    testSubject.onFiltersChanged(listOf(SessionFilter(SessionFilter.FilterType.BOOKMARK, "bookmark")))
+
+    assertEquals(
+      AgendaLayoutState(
+        rooms = emptyList(),
+        sessionFilters = listOf(SessionFilter(SessionFilter.FilterType.BOOKMARK, "bookmark"))
+      ),
+      testSubject.state.first()
+    )
+  }
+
+  @Test
+  fun `given failure in retrieving rooms state should have empty rooms`() = runBlocking {
+    fakeStore.roomsMutableFlow.value = Result.failure(RuntimeException("exception"))
+
+    assertEquals(
+      AgendaLayoutState(
+        rooms = emptyList(),
+        sessionFilters = emptyList()
+      ),
+      testSubject.state.first()
+    )
+  }
+
+  @Test
+  fun `given rooms are retrieved state should be correct`() = runBlocking {
+    fakeStore.roomsMutableFlow.value = Result.success(listOf(Room(id = "id", name = "name")))
+
+    assertEquals(
+      AgendaLayoutState(
+        rooms = listOf(Room(id = "id", name = "name")),
+        sessionFilters = emptyList()
+      ),
+      testSubject.state.first()
+    )
+  }
+}


### PR DESCRIPTION
I used rememberSaveable rather than remember in order to preserve the filters across recreations.

Also to be able to save the `SessionFilter`, I noticed that `value` is always a `String`, so I thought it would be appropriate to convert to String in order to make it fully Parcelable. If we wanted to have a more extensible solution for the future, perhaps we could adopt a sealed class approach, where each subtype is a `FilterType`. however, I thought that might be overkill, and let's settle for a simpler approach that does the job decent enough. 

Fixes #121 