### PR TITLE
Small adjustment on Speaker title alignment

### DIFF
--- a/app/src/main/java/fr/paug/androidmakers/ui/components/speakers/SpeakerScreen.kt
+++ b/app/src/main/java/fr/paug/androidmakers/ui/components/speakers/SpeakerScreen.kt
@@ -170,11 +170,13 @@ fun SpeakerItem(
             )
         )
       },
-      supportingContent = {
-        Text(
-            text = speaker.company.orEmpty(),
-            style = MaterialTheme.typography.labelMedium,
-        )
+      supportingContent = speaker.company?.let { company ->
+        {
+          Text(
+              text = company,
+              style = MaterialTheme.typography.labelMedium,
+          )
+        }
       },
       leadingContent = {
         AsyncImage(


### PR DESCRIPTION
When the speaker has no "company", the alignment of the name was incorrect.

I don't know if the absence of company is an issue or a feature, though 🧐