### PR TITLE
Forces the wear app splash screen to always display the icon.

### DIFF
--- a/wearApp/src/main/res/values/styles.xml
+++ b/wearApp/src/main/res/values/styles.xml
@@ -1,8 +1,9 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="MainActivityTheme.Starting" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@android:color/black</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
         <item name="postSplashScreenTheme">@android:style/Theme.DeviceDefault</item>
+        <item name="android:windowSplashScreenBehavior" tools:targetApi="33">icon_preferred</item>
     </style>
 </resources>


### PR DESCRIPTION
Forces the wear app splash screen to always display the icon.

## Motivation

Avoid the app from being rejected because of the "Missing app icon in splash screen" issue.

## References

[Splash screen API](https://developer.android.com/develop/ui/views/launch/splash-screen#set-theme)
[Wear guidelines](https://developer.android.com/design/ui/wear/guides/behaviors-and-patterns/launch#branded)