### PR TITLE
Use 2024 data

### DIFF
--- a/shared/data/src/androidMain/kotlin/fr/androidmakers/store/graphql/ApolloClientBuilder.android.kt
+++ b/shared/data/src/androidMain/kotlin/fr/androidmakers/store/graphql/ApolloClientBuilder.android.kt
@@ -27,10 +27,13 @@ actual class ApolloClientBuilder(
                 request.newBuilder()
                     .addHeader("conference", conference)
                     .apply {
-                      val token = Firebase.auth.currentUser?.getIdToken(false)?.result?.token
-                      if (token != null) {
-                        addHeader("Authorization", "Bearer $token")
-                      }
+                      /**
+                       *
+                       */
+//                      val token = Firebase.auth.currentUser?.getIdToken(false)?.result?.token
+//                      if (token != null) {
+//                        addHeader("Authorization", "Bearer $token")
+//                      }
                     }
                     .build()
             )

--- a/shared/data/src/commonMain/graphql/operations.graphql
+++ b/shared/data/src/commonMain/graphql/operations.graphql
@@ -27,7 +27,7 @@ fragment SessionDetails on Session {
         id
     }
     tags
-    isServiceSession
+    #isServiceSession
 }
 
 

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/mappers.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/mappers.kt
@@ -56,7 +56,7 @@ fun SessionDetails.toSession(): Session {
       roomId = this.room?.id ?: "",
       endsAt = this.endsAt,
       startsAt = this.startsAt,
-      isServiceSession = isServiceSession
+      isServiceSession = false //isServiceSession
   )
 }
 

--- a/shared/di/src/androidMain/kotlin/fr/androidmakers/di/DataModule.android.kt
+++ b/shared/di/src/androidMain/kotlin/fr/androidmakers/di/DataModule.android.kt
@@ -10,8 +10,8 @@ import org.koin.dsl.module
 actual val dataPlatformModule = module {
   single { ApolloClientBuilder(
       androidContext(),
-      "https://androidmakers-2023.ew.r.appspot.com/graphql",
-      "androidmakers2023")
+    "https://confetti-app.dev/graphql",
+      "androidmakers2024")
   }
 
   single<DataStore<Preferences>> {

--- a/shared/di/src/iosMain/kotlin/fr/androidmakers/di/DataModule.ios.kt
+++ b/shared/di/src/iosMain/kotlin/fr/androidmakers/di/DataModule.ios.kt
@@ -13,7 +13,7 @@ import platform.Foundation.NSUserDomainMask
 
 @OptIn(ExperimentalForeignApi::class)
 actual val dataPlatformModule = module {
-  single { ApolloClientBuilder("https://androidmakers-2023.ew.r.appspot.com/graphql", "androidmakers2023", "") }
+  single { ApolloClientBuilder("https://confetti-app.dev/graphql", "androidmakers2024", "") }
 
   single<DataStore<Preferences>> {
     createDataStore {

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaUtils.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaUtils.kt
@@ -44,7 +44,7 @@ fun Session.toUISession(
       endDate = endsAt.toInstant(eventTimeZone),
       language = language,
       roomId = roomId,
-      room = rooms[roomId]!!.name,
+      room = rooms[roomId]?.name ?: "unknown",
       speakers = this.speakers.mapNotNull { speakers[it]?.toUISpeaker() },
       isServiceSession = isServiceSession,
       isFavorite = isFavorite


### PR DESCRIPTION
Not 100% perfect yet but at least we'll test using real data. Still missing:

* isServiceSession
* Authentified calls are not working
* Venue

If you want to test OpenFeedback, you'll have to set your device Clock in the future 👽 

Next steps:
* switching the endpoint to our own instance of Confetti so that we can authentify with our own firebase project. 
* fix isServiceSession and Venue calls
* add OpenFeedback debug setting to avoid changing the device clock

<img src="https://github.com/paug/AndroidMakersApp/assets/3974977/24edeed8-5414-4e42-a077-d5c0e3efdc21" width=250/>
