### PR TITLE
Wear app: Scroll to next session

### DIFF
--- a/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/common/PulsatingRedDot.kt
+++ b/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/common/PulsatingRedDot.kt
@@ -1,0 +1,47 @@
+package fr.paug.androidmakers.wear.ui.common
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.dp
+import fr.paug.androidmakers.wear.ui.theme.amRed
+
+@Composable
+fun Pulsating(content: @Composable () -> Unit) {
+  val infiniteTransition = rememberInfiniteTransition(label = "pulse")
+
+  val scale by infiniteTransition.animateFloat(
+    label = "pulse",
+    initialValue = 1f,
+    targetValue = 0f,
+    animationSpec = infiniteRepeatable(
+      animation = tween(500),
+      repeatMode = RepeatMode.Reverse
+    )
+  )
+
+  Box(modifier = Modifier.alpha(scale)) {
+    content()
+  }
+}
+
+@Composable
+fun PulsatingRedDot() {
+  Pulsating {
+    Box(
+      modifier = Modifier
+        .size(8.dp)
+        .background(color = amRed, shape = CircleShape)
+    )
+  }
+}

--- a/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/session/UISession.kt
+++ b/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/session/UISession.kt
@@ -3,12 +3,27 @@ package fr.paug.androidmakers.wear.ui.session
 import fr.androidmakers.domain.model.Room
 import fr.androidmakers.domain.model.Session
 import fr.androidmakers.domain.model.Speaker
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 data class UISession(
-    val session: Session,
-    val speakers: List<Speaker>,
-    val room: Room,
-    val isBookmarked: Boolean,
+  val session: Session,
+  val speakers: List<Speaker>,
+  val room: Room,
+  val isBookmarked: Boolean,
 ) {
   val formattedDuration: String = session.duration.inWholeMinutes.toString() + " min"
+
+  val isOver: Boolean
+    get() {
+      val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+      return session.endsAt < now
+    }
+
+  val isOngoing: Boolean
+    get() {
+      val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+      return session.startsAt <= now && now <= session.endsAt
+    }
 }

--- a/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/session/details/SessionDetailScreen.kt
+++ b/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/session/details/SessionDetailScreen.kt
@@ -34,6 +34,7 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import fr.paug.androidmakers.wear.ui.common.Loading
+import fr.paug.androidmakers.wear.ui.common.PulsatingRedDot
 import fr.paug.androidmakers.wear.ui.session.UISession
 import fr.paug.androidmakers.wear.ui.session.uiSession1
 import fr.paug.androidmakers.wear.ui.theme.amRed
@@ -86,6 +87,10 @@ private fun Session(session: UISession) {
 
             Spacer(modifier = Modifier.width(16.dp))
 
+            if (session.isOngoing) {
+              PulsatingRedDot()
+              Spacer(modifier = Modifier.width(2.dp))
+            }
             Text(
               text = session.formattedDuration,
             )

--- a/wearApp/src/main/res/values/styles.xml
+++ b/wearApp/src/main/res/values/styles.xml
@@ -5,5 +5,6 @@
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
         <item name="postSplashScreenTheme">@android:style/Theme.DeviceDefault</item>
         <item name="android:windowSplashScreenBehavior" tools:targetApi="33">icon_preferred</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 </resources>


### PR DESCRIPTION
- Sessions that are over are grayed out
- Sessions that are ongoing have a red blinking dot
- Automatically scroll to the next not over session in the list

In this example I've set the watch to the 25th of April, at 14h15:

[scroll.webm](https://github.com/paug/AndroidMakersApp/assets/372852/f79f70e7-c778-4aed-9d33-f8a1a154905a)
