### PR TITLE
Fix a weird scroll when opening the floor plan screen

### DIFF
--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/venue/FloorPlan.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/venue/FloorPlan.kt
@@ -2,21 +2,22 @@ package com.androidmakers.ui.venue
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
 import com.seiko.imageloader.rememberImagePainter
-import dev.icerock.moko.resources.compose.painterResource
-import fr.paug.androidmakers.ui.MR
 
 @Composable
 fun FloorPlan(floorPlanUrl: String) {
-  Box(modifier = Modifier.verticalScroll(rememberScrollState())) {
+  Box(
+      modifier = Modifier
+          .fillMaxWidth()
+          .fillMaxHeight()
+          .verticalScroll(rememberScrollState())
+  ) {
     val painter = rememberImagePainter(floorPlanUrl)
 
     Image(


### PR DESCRIPTION
When switching from Afterparty tab to the Floor Plan tab, a small space at the top of the map and quickly disappear after.
Clearly specifying size modifiers of the `Box` fixes the issue