### PR TITLE
Wear app: better splash screen

### DIFF
--- a/wearApp/src/main/res/values/styles.xml
+++ b/wearApp/src/main/res/values/styles.xml
@@ -1,10 +1,11 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="MainActivityTheme.Starting" parent="Theme.SplashScreen">
+    <style name="MainActivityTheme.Starting" parent="Theme.SplashScreen.IconBackground">
         <item name="windowSplashScreenBackground">@android:color/black</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
         <item name="postSplashScreenTheme">@android:style/Theme.DeviceDefault</item>
         <item name="android:windowSplashScreenBehavior" tools:targetApi="33">icon_preferred</item>
         <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="windowSplashScreenIconBackgroundColor">@android:color/white</item>
     </style>
 </resources>


### PR DESCRIPTION
It now looks like this: 

![Screenshot_1712930006](https://github.com/paug/AndroidMakersApp/assets/372852/f4da2cfa-7ad1-463c-ba2d-af21b1a63818)

(following https://developer.android.com/training/wearables/apps/splash-screen)