### PR TITLE
Always call firebase getIdToken()

### DIFF
--- a/androidApp/src/main/java/fr/paug/androidmakers/MainActivity.kt
+++ b/androidApp/src/main/java/fr/paug/androidmakers/MainActivity.kt
@@ -112,7 +112,7 @@ class MainActivity : AppCompatActivity() {
                 val result = auth.signInWithCredential(firebaseCredential)
                 // Sign in success, update UI with the signed-in user's information
                 lifecycleScope.launch {
-                  UserData().userRepository.setUser(result.user?.toUser())
+                  UserData().userRepository.setUser(result.user)
                   println("user id=${result.user?.uid}")
                   println("idToken=${result.user?.getIdToken(true)}")
                 }
@@ -160,4 +160,5 @@ class MainActivity : AppCompatActivity() {
     const val REQ_SIGNIN = 33
   }
 }
+
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ apollo-adapters = { module = "com.apollographql.apollo3:apollo-adapters" }
 apollo-normalized-cache = { module = "com.apollographql.apollo3:apollo-normalized-cache" }
 apollo-normalized-cache-sqlite = { module = "com.apollographql.apollo3:apollo-normalized-cache-sqlite" }
 apollo-runtime = { module = "com.apollographql.apollo3:apollo-runtime" }
+atomicfu = "org.jetbrains.kotlinx:atomicfu:0.20.1"
 shared-preferences = "androidx.preference:preference:1.2.1"
 coil-compose = "io.coil-kt:coil-compose:2.5.0"
 qdsfdhvh-imageloader = { module = "io.github.qdsfdhvh:image-loader", version.ref = "image-loader" }

--- a/shared/data/build.gradle.kts
+++ b/shared/data/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
         implementation(libs.apollo.normalized.cache.sqlite)
         implementation(libs.apollo.normalized.cache)
 
+        implementation(libs.atomicfu)
         implementation(libs.androidx.datastore.preferences.core)
         api(libs.androidx.datastore.preferences)
 

--- a/shared/data/src/androidMain/kotlin/fr/androidmakers/store/graphql/ApolloClientBuilder.android.kt
+++ b/shared/data/src/androidMain/kotlin/fr/androidmakers/store/graphql/ApolloClientBuilder.android.kt
@@ -35,7 +35,7 @@ actual class ApolloClientBuilder(
                       /**
                        *
                        */
-                      val token = userRepository.getUser()?.idToken
+                      val token = userRepository.getIdToken()
                       if (token != null) {
                         addHeader("Authorization", "Bearer $token")
                       }

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/firebase/FirebaseUserRepository.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/firebase/FirebaseUserRepository.kt
@@ -5,10 +5,7 @@ import dev.gitlive.firebase.auth.FirebaseUser
 import dev.gitlive.firebase.auth.auth
 import fr.androidmakers.domain.model.User
 import fr.androidmakers.domain.repo.UserRepository
-import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
-import kotlinx.atomicfu.locks.reentrantLock
-import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/firebase/FirebaseUserRepository.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/firebase/FirebaseUserRepository.kt
@@ -1,9 +1,14 @@
 package fr.androidmakers.store.firebase
 
 import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.auth.FirebaseUser
 import dev.gitlive.firebase.auth.auth
 import fr.androidmakers.domain.model.User
 import fr.androidmakers.domain.repo.UserRepository
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,12 +16,13 @@ import kotlinx.coroutines.launch
 
 @OptIn(DelicateCoroutinesApi::class)
 class FirebaseUserRepository : UserRepository {
+  private var currentUser = atomic<FirebaseUser?>(null)
   override val user = MutableStateFlow<User?>(null)
 
   init {
     GlobalScope.launch {
       try {
-        setUser(Firebase.auth.currentUser?.toUser())
+        setUser(Firebase.auth.currentUser)
       } catch (e: Exception) {
         e.printStackTrace()
       }
@@ -27,7 +33,15 @@ class FirebaseUserRepository : UserRepository {
     return user.value
   }
 
-  override suspend fun setUser(user: User?) {
-    this.user.emit(user)
+  override suspend fun getIdToken(): String? {
+    return currentUser.value?.getIdToken(false)
+  }
+
+  override suspend fun setUser(user: Any?) {
+    check(user is FirebaseUser?) {
+      "Expected FirebaseUser, got '$user'"
+    }
+    currentUser.value = user
+    this.user.emit(user?.toUser())
   }
 }

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/firebase/mappers.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/firebase/mappers.kt
@@ -4,5 +4,5 @@ import dev.gitlive.firebase.auth.FirebaseUser
 import fr.androidmakers.domain.model.User
 
 suspend fun FirebaseUser.toUser(): User {
-  return User(uid, photoURL, this.getIdToken(false))
+  return User(uid, photoURL)
 }

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/model/User.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/model/User.kt
@@ -1,10 +1,6 @@
 package fr.androidmakers.domain.model
 
-import okio.Buffer
-import okio.ByteString.Companion.decodeBase64
-
 data class User(
     val id: String,
     val photoUrl: String?,
-    val idToken: String?
 )

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/UserRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/UserRepository.kt
@@ -6,5 +6,6 @@ import kotlinx.coroutines.flow.StateFlow
 interface UserRepository {
   val user: StateFlow<User?>
   fun getUser(): User?
-  suspend fun setUser(user: User?)
+  suspend fun getIdToken(): String?
+  suspend fun setUser(user: Any?)
 }

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/UserViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/UserViewModel.kt
@@ -7,3 +7,5 @@ import org.koin.core.component.inject
 class UserData: KoinComponent {
   val userRepository: UserRepository by inject()
 }
+
+

--- a/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/signin/GoogleSignInViewModel.kt
+++ b/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/signin/GoogleSignInViewModel.kt
@@ -38,7 +38,7 @@ class GoogleSignInViewModel(
         try {
           val credential = GoogleAuthProvider.getCredential(idToken!!, null)
           Firebase.auth.signInWithCredential(credential).await()
-          UserData().userRepository.setUser(Firebase.auth.currentUser?.toUser())
+          UserData().userRepository.setUser(Firebase.auth.currentUser)
           onSignInSuccess()
         } catch (e: FirebaseAuthException) {
           Log.w(TAG, "Could not get Firebase auth credential from Google id token", e)
@@ -53,7 +53,6 @@ private suspend fun FirebaseUser.toUser(): User {
   return User(
     id = this.uid,
     photoUrl = this.photoUrl.toString(),
-    idToken = this.getIdToken(true).await().token
   )
 }
 


### PR DESCRIPTION
Do not cache the `idToken` in RAM. Calling `getIdToken` instead gives a chance to Firebase auth to refresh the token if needed