### PR TITLE
Call openUrl with a completionCallback, seems to fix a freeze

### DIFF
--- a/shared/domain/src/iosMain/kotlin/fr/androidmakers/domain/utils/UrlOpener.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/fr/androidmakers/domain/utils/UrlOpener.ios.kt
@@ -2,13 +2,24 @@ package fr.androidmakers.domain.utils
 
 import platform.Foundation.NSURL
 import platform.UIKit.UIApplication
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 
 actual class UrlOpener {
   actual fun openUrl(url: String): Boolean {
     val urlObj = NSURL(string = url)
     return if (UIApplication.sharedApplication.canOpenURL(urlObj)) {
-      UIApplication.sharedApplication.openURL(urlObj)
+      val application = UIApplication.sharedApplication
+
+      application.openURL(url = urlObj, options = emptyMap<Any?, Any>()) {
+        if (!it) {
+          println("Could not open $url")
+        }
+      }
       true
-    } else { false }
+    } else {
+      false
+    }
   }
 }
+


### PR DESCRIPTION
I had something "__NSXPCCONNECTION_IS_WAITING_FOR_A_SYNCHRONOUS_REPLY__" in the stacktrace. Not sure what this means but with a completion handler I can't reproduce anymore 🤷 

Closes #269 