### PR TITLE
Ensure Android deep links are only launched once and don't make the app crash

### DIFF
--- a/androidApp/src/main/java/fr/paug/androidmakers/MainActivity.kt
+++ b/androidApp/src/main/java/fr/paug/androidmakers/MainActivity.kt
@@ -1,5 +1,6 @@
 package fr.paug.androidmakers
 
+import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.util.Log

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/MainLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/MainLayout.kt
@@ -56,11 +56,15 @@ private fun MainNavHost(
     signingCallbacks: SigninCallbacks,
     deeplink: String? = null,
 ) {
-    LaunchedEffect(deeplink) {
-        deeplink?.let {
-            mainNavController.navigate(deeplink)
-        }
+  LaunchedEffect(deeplink) {
+    deeplink?.let {
+      try {
+        mainNavController.navigate(deeplink)
+      } catch (e: IllegalStateException) {
+        // Invalid route URL
+      }
     }
+  }
 
   NavHost(
       navigator = mainNavController,


### PR DESCRIPTION
- The Activity reads `intent.data` after being re-created which causes the initial deep link to be launched again, even after the user navigates away to another screen or if another deep link has been received in the meantime. To avoid this, return `null` as deep link when `savedInstanceState` is non-null after re-creation.
- `addOnNewIntentListener()` is called during each recomposition but the listener is never unregistered which can cause a leak and multiple navigator calls. To avoid this and make the code cleaner, use the `produceState()` function to encapsulate all `deeplink` state logic and unregister the listener in `awaitDispose {}`.
- Catch `IllegalStateException` thrown by `Navigator.navigate(url)` when the url doesn't match any route.