### PR TITLE
Paginate sessions

### DIFF
--- a/androidApp/src/test/java/fr/paug/androidmakers/fixtures/FakeAndroidMakersStore.kt
+++ b/androidApp/src/test/java/fr/paug/androidmakers/fixtures/FakeAndroidMakersStore.kt
@@ -39,7 +39,7 @@ class FakeAndroidMakersStore : RoomsRepository, VenueRepository, SpeakersReposit
     TODO("Not yet implemented")
   }
 
-  override fun getSessions(): Flow<Result<List<Session>>> {
+  override fun watchSessions(): Flow<Result<List<Session>>> {
     TODO("Not yet implemented")
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,8 +39,8 @@ androidx-credentials-playServicesAuth = { group = "androidx.credentials", name =
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 apollo-adapters = { module = "com.apollographql.apollo3:apollo-adapters", version.ref = "apollo" }
-apollo-normalized-cache = { module = "com.apollographql.apollo3:apollo-normalized-cache", version.ref = "apollo" }
-apollo-normalized-cache-sqlite = { module = "com.apollographql.apollo3:apollo-normalized-cache-sqlite", version.ref = "apollo" }
+apollo-normalized-cache = { module = "com.apollographql.apollo3:apollo-normalized-cache-incubating", version.ref = "apollo" }
+apollo-normalized-cache-sqlite = { module = "com.apollographql.apollo3:apollo-normalized-cache-sqlite-incubating", version.ref = "apollo" }
 apollo-runtime = { module = "com.apollographql.apollo3:apollo-runtime", version.ref = "apollo" }
 atomicfu = "org.jetbrains.kotlinx:atomicfu:0.23.2"
 qdsfdhvh-imageloader = { module = "io.github.qdsfdhvh:image-loader", version.ref = "image-loader" }

--- a/shared/data/src/commonMain/graphql/extra.graphqls
+++ b/shared/data/src/commonMain/graphql/extra.graphqls
@@ -1,10 +1,20 @@
-# noinspection GraphQLUnresolvedReference,GraphQLMissingType
+extend schema
+@link(
+    url: "https://specs.apollo.dev/kotlin_labs/v0.3",
+    import: ["@typePolicy", "@fieldPolicy"]
+)
 
 extend type Room @typePolicy(keyFields: "id")
 
 extend type Session @typePolicy(keyFields: "id")
-extend type RootQuery @fieldPolicy(forField: "session", keyArgs: "id")
+
+extend type RootQuery
+@fieldPolicy(forField: "session", keyArgs: "id")
+@fieldPolicy(forField: "sessions", paginationArgs: "first after")
+@typePolicy(embeddedFields: "sessions")
 
 extend type Speaker @typePolicy(keyFields: "id")
 
 extend type Venue @typePolicy(keyFields: "name")
+
+extend type SessionConnection @typePolicy(embeddedFields: "pageInfo")

--- a/shared/data/src/commonMain/graphql/operations.graphql
+++ b/shared/data/src/commonMain/graphql/operations.graphql
@@ -1,7 +1,10 @@
-query GetSessions {
-    sessions(first: 1000) {
+query GetSessions($after: String) {
+    sessions(first: 10, after: $after) {
         nodes {
             ...SessionDetails
+        }
+        pageInfo {
+            endCursor
         }
     }
 }

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/ApolloClient.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/ApolloClient.kt
@@ -1,9 +1,14 @@
 package fr.androidmakers.store.graphql
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
+import com.apollographql.apollo3.cache.normalized.api.FieldRecordMerger
+import com.apollographql.apollo3.cache.normalized.api.FieldRecordMerger.FieldMerger
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
+import com.apollographql.apollo3.cache.normalized.api.MetadataGeneratorContext
 import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.apollo3.network.http.HttpInterceptor
@@ -17,25 +22,83 @@ fun ApolloClient(
   userRepository: UserRepository,
 ): ApolloClient {
   val memoryCacheFactory = MemoryCacheFactory(20_000_000).chain(sqlNormalizedCacheFactory)
+  @OptIn(ApolloExperimental::class)
   return ApolloClient.Builder()
-      .serverUrl("https://androidmakers.fr/graphql")
-      .addHttpInterceptor(object : HttpInterceptor {
-        override suspend fun intercept(request: HttpRequest, chain: HttpInterceptorChain): HttpResponse {
-          return chain.proceed(
-            request.newBuilder()
-              .apply {
-                /**
-                 *
-                 */
-                val token = getIdToken(userRepository)
-                if (token != null) {
-                  addHeader("Authorization", "Bearer $token")
-                }
+    .serverUrl("https://androidmakers.fr/graphql")
+    .addHttpInterceptor(object : HttpInterceptor {
+      override suspend fun intercept(
+        request: HttpRequest,
+        chain: HttpInterceptorChain
+      ): HttpResponse {
+        return chain.proceed(
+          request.newBuilder()
+            .apply {
+              /**
+               *
+               */
+              val token = getIdToken(userRepository)
+              if (token != null) {
+                addHeader("Authorization", "Bearer $token")
               }
-              .build()
-          )
-        }
-      })
-      .normalizedCache(memoryCacheFactory)
-      .build()
+            }
+            .build()
+        )
+      }
+    })
+    .normalizedCache(
+      normalizedCacheFactory = memoryCacheFactory,
+      metadataGenerator = AndroidMakersMetaDataGenerator,
+      recordMerger = FieldRecordMerger(AndroidMakersFieldMerger),
+    )
+    .build()
+}
+
+@OptIn(ApolloExperimental::class)
+object AndroidMakersMetaDataGenerator : MetadataGenerator {
+  @Suppress("UNCHECKED_CAST")
+  override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> {
+    return if (context.field.type.rawType().name == "SessionConnection") {
+      obj as Map<String, Any?>
+      val pageInfo = obj["pageInfo"] as? Map<String, Any?>
+      val endCursor = pageInfo?.get("endCursor") as? String
+      mapOf(
+        "endCursor" to endCursor,
+        "after" to context.argumentValue("after"),
+      )
+    } else {
+      emptyMap()
+    }
+  }
+}
+
+@OptIn(ApolloExperimental::class)
+object AndroidMakersFieldMerger : FieldMerger {
+  @Suppress("UNCHECKED_CAST")
+  override fun mergeFields(
+    existing: FieldRecordMerger.FieldInfo,
+    incoming: FieldRecordMerger.FieldInfo
+  ): FieldRecordMerger.FieldInfo {
+    val existingEndCursor = existing.metadata["endCursor"] as? String
+    val incomingAfterArgument = incoming.metadata["after"] as? String
+    return if (existingEndCursor == null && incomingAfterArgument == null) {
+      incoming
+    } else if (incomingAfterArgument == existingEndCursor) {
+      val existingValue = existing.value as Map<String, Any?>
+      val existingNodes = existingValue["nodes"] as? List<*>
+
+      val incomingValue = incoming.value as Map<String, Any?>
+      val incomingNodes = incomingValue["nodes"] as? List<*>
+
+      val mergedNodes: List<*> = existingNodes.orEmpty() + incomingNodes.orEmpty()
+      val mergedValue = (existingValue + incomingValue).toMutableMap()
+      mergedValue["nodes"] = mergedNodes
+
+      FieldRecordMerger.FieldInfo(
+        value = mergedValue,
+        metadata = incoming.metadata,
+      )
+    } else {
+      incoming
+    }
+  }
 }

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/SessionsGraphQLRepository.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/SessionsGraphQLRepository.kt
@@ -1,8 +1,10 @@
 package fr.androidmakers.store.graphql
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
+import com.apollographql.apollo3.cache.normalized.watch
 import fr.androidmakers.domain.model.Session
 import fr.androidmakers.domain.repo.SessionsRepository
 import kotlinx.coroutines.flow.Flow
@@ -37,9 +39,22 @@ class SessionsGraphQLRepository(private val apolloClient: ApolloClient) : Sessio
       .toResultFlow()
   }
 
-  override fun getSessions(): Flow<Result<List<Session>>> {
-    return apolloClient.query(GetSessionsQuery())
-      .cacheAndNetwork()
-      .map { it.map { it.sessions.nodes.map { it.sessionDetails.toSession() } } }
+  override fun watchSessions(): Flow<List<Session>> {
+    return apolloClient.query(GetSessionsQuery(after = Optional.present(null)))
+      .fetchPolicy(FetchPolicy.CacheAndNetwork)
+      .watch()
+      .map { it.data?.sessions?.nodes?.map { it.sessionDetails.toSession() }.orEmpty() }
+  }
+
+  override suspend fun fetchNextSessionsPage() {
+    val cacheResponse = apolloClient.query(GetSessionsQuery())
+      .fetchPolicy(FetchPolicy.CacheOnly)
+      .execute()
+    val endCursor = cacheResponse.data?.sessions?.pageInfo?.endCursor
+    if (endCursor != null) {
+      apolloClient.query(GetSessionsQuery(Optional.present(endCursor)))
+        .fetchPolicy(FetchPolicy.NetworkOnly)
+        .execute()
+    }
   }
 }

--- a/shared/di/src/commonMain/kotlin/fr/androidmakers/di/DomainModule.kt
+++ b/shared/di/src/commonMain/kotlin/fr/androidmakers/di/DomainModule.kt
@@ -1,6 +1,7 @@
 package fr.androidmakers.di
 
 import fr.androidmakers.domain.interactor.ApplyForAppClinicUseCase
+import fr.androidmakers.domain.interactor.FetchNextSessionsPageUseCase
 import fr.androidmakers.domain.interactor.GetAfterpartyVenueUseCase
 import fr.androidmakers.domain.interactor.GetAgendaUseCase
 import fr.androidmakers.domain.interactor.GetConferenceVenueUseCase
@@ -22,6 +23,7 @@ expect val domainPlatformModule: Module
 
 val domainModule = module {
   factory { GetAgendaUseCase(get(), get(), get()) }
+  factory { FetchNextSessionsPageUseCase(get()) }
   factory { GetConferenceVenueUseCase(get()) }
   factory { GetAfterpartyVenueUseCase(get()) }
   factory { MergeBookmarksUseCase(get(), get()) }

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/FetchNextSessionsPageUseCase.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/FetchNextSessionsPageUseCase.kt
@@ -1,0 +1,11 @@
+package fr.androidmakers.domain.interactor
+
+import fr.androidmakers.domain.repo.SessionsRepository
+
+class FetchNextSessionsPageUseCase(
+  private val sessionsRepository: SessionsRepository,
+) {
+  suspend operator fun invoke() {
+    sessionsRepository.fetchNextSessionsPage()
+  }
+}

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/GetAgendaUseCase.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/GetAgendaUseCase.kt
@@ -14,15 +14,11 @@ class GetAgendaUseCase(
 ) {
   operator fun invoke(): Flow<Result<Agenda>> {
     return combine(
-        sessionsRepository.getSessions(),
+      sessionsRepository.watchSessions(),
         roomsRepository.getRooms(),
         speakersRepository.getSpeakers(),
     ) { sessions, rooms, speakers ->
 
-      sessions.exceptionOrNull()?.let {
-        it.printStackTrace()
-        return@combine Result.failure(it)
-      }
       rooms.exceptionOrNull()?.let {
         it.printStackTrace()
         return@combine Result.failure(it)
@@ -34,7 +30,7 @@ class GetAgendaUseCase(
 
       Result.success(
           Agenda(
-              sessions = sessions.getOrThrow().associateBy { it.id },
+            sessions = sessions.associateBy { it.id },
               rooms = rooms.getOrThrow().associateBy { it.id },
               speakers = speakers.getOrThrow().associateBy { it.id }
           )

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/SessionsRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/SessionsRepository.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.flow.Flow
 interface SessionsRepository {
   fun getSession(id: String): Flow<Result<Session>>
 
-  fun getSessions(): Flow<Result<List<Session>>>
+  fun watchSessions(): Flow<List<Session>>
+
+  suspend fun fetchNextSessionsPage()
 
   fun getBookmarks(userId: String): Flow<Result<Set<String>>>
 

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/di/ViewModelModule.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/di/ViewModelModule.kt
@@ -16,7 +16,7 @@ val viewModelModule = module {
   factory { VenueViewModel(get(), get(), get()) }
   factory { (speakerId: String) -> SpeakerDetailsViewModel(speakerId, get(), get()) }
   factory { AgendaLayoutViewModel(get()) }
-  factory { AgendaPagerViewModel(get(), get(), get(), get()) }
+  factory { AgendaPagerViewModel(get(), get(), get(), get(), get()) }
   factory { (sessionId: String) -> SessionDetailViewModel(sessionId, get(), get(), get(), get(), get(), get(), get(), get()) }
   factory { AboutViewModel(get(), get(), get(), get(), get()) }
 }

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaColumn.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaColumn.kt
@@ -37,6 +37,7 @@ fun AgendaColumn(
   onSessionClicked: (UISession) -> Unit,
   onSessionBookmarked: (UISession, Boolean) -> Unit,
   onApplyForAppClinicClicked: () -> Unit,
+  onFetchMoreItems: () -> Unit,
 ) {
   val listState = rememberLazyListState()
 
@@ -103,6 +104,10 @@ fun AgendaColumn(
           }
         }
       }
+    }
+
+    item {
+      onFetchMoreItems()
     }
   }
 }

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPager.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPager.kt
@@ -27,45 +27,46 @@ import moe.tlaster.precompose.koin.koinViewModel
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AgendaPager(
-    initialPageIndex: Int,
-    days: List<String>,
-    onSessionClicked: (UISession) -> Unit,
-    filterList: List<SessionFilter>
+  initialPageIndex: Int,
+  days: List<String>,
+  onSessionClicked: (UISession) -> Unit,
+  filterList: List<SessionFilter>
 ) {
   Column(
-      modifier = Modifier.fillMaxWidth()
+    modifier = Modifier.fillMaxWidth()
   ) {
 
     val pagerState = rememberPagerState(
-        pageCount = { days.size }, initialPage = initialPageIndex)
+      pageCount = { days.size }, initialPage = initialPageIndex
+    )
 
     TabRow(
-        selectedTabIndex = pagerState.currentPage,
-        containerColor = MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground
+      selectedTabIndex = pagerState.currentPage,
+      containerColor = MaterialTheme.colorScheme.background,
+      contentColor = MaterialTheme.colorScheme.onBackground
     ) {
       repeat(days.size) {
         val coroutineScope = rememberCoroutineScope()
 
         Tab(
-            text = {
-              Text(days[it])
-            },
-            selected = pagerState.currentPage == it,
-            selectedContentColor = MaterialTheme.colorScheme.onSurface,
-            unselectedContentColor = MaterialTheme.colorScheme.onSurface,
-            onClick = {
-              coroutineScope.launch {
-                pagerState.animateScrollToPage(it)
-              }
-            },
+          text = {
+            Text(days[it])
+          },
+          selected = pagerState.currentPage == it,
+          selectedContentColor = MaterialTheme.colorScheme.onSurface,
+          unselectedContentColor = MaterialTheme.colorScheme.onSurface,
+          onClick = {
+            coroutineScope.launch {
+              pagerState.animateScrollToPage(it)
+            }
+          },
 
-            )
+          )
       }
     }
 
     HorizontalPager(
-        state = pagerState,
+      state = pagerState,
     ) { page ->
       val viewModel = koinViewModel(vmClass = AgendaPagerViewModel::class)
       val favoriteSessions by viewModel.getFavoriteSessions().collectAsState(emptySet())
@@ -76,16 +77,17 @@ fun AgendaPager(
           EmptyLayout()
         } else {
           items.filter { favoriteSessions.contains(it.id) }.forEach {
-              it.isFavorite = true
+            it.isFavorite = true
           }
           val platformContext = getPlatformContext()
           AgendaColumn(
-              sessionsPerStartTime = addSeparators(items),
-              onSessionClicked = onSessionClicked,
-              onApplyForAppClinicClicked = { viewModel.applyForAppClinic(platformContext) },
-              onSessionBookmarked = { uiSession, bookmarked ->
-                viewModel.setSessionBookmark(uiSession, bookmarked)
-              }
+            sessionsPerStartTime = addSeparators(items),
+            onSessionClicked = onSessionClicked,
+            onApplyForAppClinicClicked = { viewModel.applyForAppClinic(platformContext) },
+            onSessionBookmarked = { uiSession, bookmarked ->
+              viewModel.setSessionBookmark(uiSession, bookmarked)
+            },
+            onFetchMoreItems = { viewModel.fetchNextSessionsPage() },
           )
         }
       }
@@ -94,16 +96,16 @@ fun AgendaPager(
 }
 
 private fun addSeparators(
-    sessions: List<UISession>
+  sessions: List<UISession>
 ): Map<String, List<UISession>> {
   return sessions.map {
     it.startDate.formatShortTime() to it
   }
-      .groupBy(
-          keySelector = { it.first }
-      ) {
-        it.second
-      }
+    .groupBy(
+      keySelector = { it.first }
+    ) {
+      it.second
+    }
 }
 
 // algorithm to filter sessions by applying filters, if the filters is same category we keep
@@ -112,14 +114,14 @@ private fun addSeparators(
 // the algorithm is inspired by Inverted index
 // time complexity is O(n * m) where n is the number of sessions and m is the number of filters
 private fun List<UISession>.filter(
-    filterList: List<SessionFilter>
+  filterList: List<SessionFilter>
 ): List<UISession> {
   if (filterList.isEmpty()) {
     return this
   }
 
   val sessionsByFilterType =
-      mutableMapOf<SessionFilter.FilterType, MutableList<UISession>>()
+    mutableMapOf<SessionFilter.FilterType, MutableList<UISession>>()
   for (filter in filterList) {
     if (!sessionsByFilterType.containsKey(filter.type)) {
       sessionsByFilterType[filter.type] = mutableListOf()

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPagerViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPagerViewModel.kt
@@ -4,6 +4,7 @@ import com.androidmakers.ui.common.LceViewModel
 import com.androidmakers.ui.model.UISession
 import fr.androidmakers.domain.PlatformContext
 import fr.androidmakers.domain.interactor.ApplyForAppClinicUseCase
+import fr.androidmakers.domain.interactor.FetchNextSessionsPageUseCase
 import fr.androidmakers.domain.interactor.GetAgendaUseCase
 import fr.androidmakers.domain.interactor.GetFavoriteSessionsUseCase
 import fr.androidmakers.domain.interactor.SetSessionBookmarkUseCase
@@ -15,6 +16,7 @@ import moe.tlaster.precompose.viewmodel.viewModelScope
 class AgendaPagerViewModel(
   private val getAgendaUseCase: GetAgendaUseCase,
   private val setSessionBookmarkUseCase: SetSessionBookmarkUseCase,
+  private val fetchNextSessionsPageUseCase: FetchNextSessionsPageUseCase,
   private val getFavoriteSessionsUseCase: GetFavoriteSessionsUseCase,
   private val applyForAppClinicUseCase: ApplyForAppClinicUseCase,
 ) : LceViewModel<Agenda>() {
@@ -34,5 +36,9 @@ class AgendaPagerViewModel(
 
   fun applyForAppClinic(platformContext: PlatformContext) {
     applyForAppClinicUseCase(platformContext)
+  }
+
+  fun fetchNextSessionsPage() = viewModelScope.launch {
+    fetchNextSessionsPageUseCase()
   }
 }


### PR DESCRIPTION
Loads the sessions by pages of 10, instead of loading the whole list immediately.

This is meant to look at how the Apollo Kotlin [pagination system](https://github.com/apollographql/apollo-kotlin/blob/main/design-docs/Normalized%20cache%20pagination.md) can be implemented in a real project.

Caveat: the pages are based on the contents of the list: when getting the first few items, we only know about Day 1, and only when scrolling to the end of Day 1 do we know that there's a Day 2, and the pager gets updated. Because of this, this can't be merged and I'll close the PR right now - at least it's a reference at how to use the pagination system that will be in the PR history.

The steps were:
1. depend on the incubating artifacts
2. update `extra.graphqls`
  2.1 mark `sessions` as embedded
  2.2 mark `sessions.first` and `.after` as pagination args
  2.3 mark `pageInfo` as embedded
3. implement a `MetaDataGenerator` to keep track of `endCursor` and `after`
4. implement a `FieldMerger` to merge the `nodes` lists
5. watch the sessions, so the UI is refreshed when a page is appended
6. add a `fetchNextSessionsPage` fun and call it from the UI when reaching the end of the LazyColumn

Note: steps 2-4 would have been simpler if the schema were following the Relay pagination spec - the rest would have been the same.

[pagination.webm](https://github.com/paug/AndroidMakersApp/assets/372852/a460282c-a888-4641-8794-a7e6f9187e32)
