### PR TITLE
Optimize Android date and time formatting

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ kotlin-plugin-compose = { group = "org.jetbrains.kotlin", name = "compose-compil
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "coroutines" }
-kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.5.0"
+kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.6.0"
 openfeedback-m3 = "io.openfeedback:openfeedback-m3:0.2.3"
 play-services-auth = "com.google.android.gms:play-services-auth:21.1.0"
 moko-resources = { module = "dev.icerock.moko:resources", version.ref = "moko" }

--- a/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/utils/DateUtils.android.kt
+++ b/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/utils/DateUtils.android.kt
@@ -1,52 +1,59 @@
+@file:SuppressLint("NewApi")
+
 package fr.androidmakers.domain.utils
 
-import android.text.format.DateUtils
+import android.annotation.SuppressLint
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.atStartOfDayIn
-import kotlinx.datetime.toInstant
-import kotlinx.datetime.toJavaLocalDateTime
-import java.text.DateFormat.MEDIUM
-import java.text.DateFormat.SHORT
-import java.text.SimpleDateFormat
+import kotlinx.datetime.toJavaLocalDate
+import kotlinx.datetime.toJavaLocalTime
+import kotlinx.datetime.toLocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
-import java.util.Date
 import java.util.Locale
-import java.util.TimeZone
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Lazily compute a value from the given key and cache it until the key changes.
+ */
+private class KeyValueCache<K, V>(private val factory: (K) -> V) {
+  private val cache = AtomicReference<Pair<K, V>?>(null)
+
+  fun get(key: K): V {
+    val currentPair = cache.get()
+    if (currentPair != null && currentPair.first == key) {
+      return currentPair.second
+    }
+    val newPair = key to factory(key)
+    // Only update the cache if it didn't change in the meantime
+    cache.compareAndSet(currentPair, newPair)
+    return newPair.second
+  }
+}
+
+private val shortTimeFormatterCache = KeyValueCache { locale: Locale ->
+  DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)
+}
+
+private val mediumDateFormatterCache = KeyValueCache { locale: Locale ->
+  DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
+}
 
 actual fun LocalDateTime.formatShortTime(): String {
-  return this.toInstant(kotlinx.datetime.TimeZone.currentSystemDefault()).formatShortTime()
+  val shortTimeFormatter = shortTimeFormatterCache.get(Locale.getDefault())
+  return time.toJavaLocalTime().format(shortTimeFormatter).lowercase(Locale.getDefault())
 }
 
 actual fun Instant.formatShortTime(): String {
-  val dateFormat = SimpleDateFormat.getTimeInstance(SHORT)
-
   // Display the time in the local time as everyone will be on site so it makes
   // planning in advance easier
-  val tz = TimeZone.getTimeZone("Europe/Paris")
-  if (tz != null) {
-    dateFormat.timeZone = tz
-  }
-
-  val date = Date(this.toEpochMilliseconds())
-  return dateFormat.format(date).lowercase(Locale.getDefault())
+  return toLocalDateTime(eventTimeZone).formatShortTime()
 }
 
 actual fun LocalDate.formatMediumDate(): String {
-  val dateFormat = SimpleDateFormat.getDateInstance(MEDIUM)
-
-  val tz = TimeZone.getTimeZone("Europe/Paris")
-  if (tz != null) {
-    dateFormat.timeZone = tz
-  }
-
-  val date = Date(
-      this.atStartOfDayIn(kotlinx.datetime.TimeZone.currentSystemDefault())
-      .toEpochMilliseconds()
-  )
-  return dateFormat.format(date).lowercase(Locale.getDefault())
+  val mediumDateFormatter = mediumDateFormatterCache.get(Locale.getDefault())
+  return toJavaLocalDate().format(mediumDateFormatter).lowercase(Locale.getDefault())
 }
 
 actual fun formatTimeInterval(startDate: LocalDateTime, endDate: LocalDateTime): String {

--- a/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/utils/DateUtils.android.kt
+++ b/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/utils/DateUtils.android.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * Memoize the result of the function call until the key changes.
  */
-private fun <K, V> ((K) -> V).memoize() : ((K) -> V) {
+private fun <K, V> ((K) -> V).memoize() : (K) -> V {
   val cache = AtomicReference<Pair<K, V>?>(null)
   return { key: K ->
     val currentPair = cache.get()

--- a/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/utils/DateUtils.android.kt
+++ b/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/utils/DateUtils.android.kt
@@ -41,8 +41,9 @@ private val mediumDateFormatterProvider = { locale: Locale ->
 }.memoize()
 
 actual fun LocalDateTime.formatShortTime(): String {
-  val shortTimeFormatter = shortTimeFormatterProvider(Locale.getDefault())
-  return time.toJavaLocalTime().format(shortTimeFormatter).lowercase(Locale.getDefault())
+  val locale = Locale.getDefault()
+  val shortTimeFormatter = shortTimeFormatterProvider(locale)
+  return time.toJavaLocalTime().format(shortTimeFormatter).lowercase(locale)
 }
 
 actual fun Instant.formatShortTime(): String {
@@ -52,8 +53,9 @@ actual fun Instant.formatShortTime(): String {
 }
 
 actual fun LocalDate.formatMediumDate(): String {
-  val mediumDateFormatter = mediumDateFormatterProvider(Locale.getDefault())
-  return toJavaLocalDate().format(mediumDateFormatter).lowercase(Locale.getDefault())
+  val locale = Locale.getDefault()
+  val mediumDateFormatter = mediumDateFormatterProvider(locale)
+  return toJavaLocalDate().format(mediumDateFormatter).lowercase(locale)
 }
 
 actual fun formatTimeInterval(startDate: LocalDateTime, endDate: LocalDateTime): String {


### PR DESCRIPTION
The current Android code uses the legacy `java.text.SimpleDateFormat` class and creates a new instance of it for every formatting. This also requires unnecessary conversion of the date or time to the legacy `Date` first.

This pull request uses the new thread-safe `DateTimeFormatter` to format `LocalDate` and `LocalTime`, the classes used internally by the kotlinx datetime types. Unwrapping the internal value is a free operation.
In addition, cache the `DateTimeFormatter` for the current `Locale` using a thread-safe custom memoization function. The cache will be invalidated when the default locale changes so the dates will always be localized properly.

Note that `DateTimeFormatter` and other `java.time` APIs are available before API 26 thanks to core library desugaring being enabled in the Android app configuration.

Finally, upgrade the kotlinx datetime library to 0.6.0.