### PR TITLE
chore: set the target JDK to 17 and upgrade CI script to build the project with JDK 21

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,11 +12,15 @@ jobs:
   build-app:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: set up JDK 17
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 17
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          validate-wrappers: true
       - name: Build with Gradle
-        run: |
-          ./gradlew assembleDebug :shared:linkDebugFrameworkIosArm64
+        run: ./gradlew clean assembleDebug

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,12 @@
-name: pr
+name: Continuous Integration
 
 on:
-  pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 # Cancel any current or previous job from the same PR
 concurrency:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Continuous Integration](https://github.com/paug/AndroidMakersApp/actions/workflows/pr.yml/badge.svg)](https://github.com/paug/AndroidMakersApp/actions/workflows/pr.yml)
+
 <h1>Android Makers conference app</h1>
 
 Android App for Android Makers (by droidcon) Paris Conferences https://androidmakers.droidcon.com
@@ -16,5 +18,3 @@ This app was built by the community 💚. PRs are welcome, see [CONTRIBUTING.md]
 <a href="https://github.com/paug/androidmakersapp/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=paug/androidmakersapp" />
 </a>
-
-

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -14,8 +15,8 @@ java {
   targetCompatibility = JavaVersion.VERSION_17
 }
 tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_17
   }
 }
 

--- a/build-logic/convention/src/main/kotlin/fr/androidmakers/plugin/AndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/fr/androidmakers/plugin/AndroidApplicationPlugin.kt
@@ -5,8 +5,10 @@ import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 class AndroidApplicationPlugin : Plugin<Project> {
@@ -48,8 +50,8 @@ internal fun Project.configureKotlinAndroid(
 
 private fun Project.configureKotlin() {
   tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_17.toString()
+    compilerOptions {
+      jvmTarget = JvmTarget.JVM_17
     }
   }
 }

--- a/build-logic/convention/src/main/kotlin/fr/androidmakers/plugin/AndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/fr/androidmakers/plugin/AndroidApplicationPlugin.kt
@@ -37,7 +37,6 @@ internal fun Project.configureKotlinAndroid(
       minSdk = libs.findVersion("sdk.min").get().displayName.toInt()
     }
 
-
     compileOptions {
       sourceCompatibility = JavaVersion.VERSION_17
       targetCompatibility = JavaVersion.VERSION_17

--- a/build-logic/convention/src/main/kotlin/fr/androidmakers/plugin/MultiplatformLibraryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/fr/androidmakers/plugin/MultiplatformLibraryPlugin.kt
@@ -3,10 +3,8 @@ package fr.androidmakers.plugin
 import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
 class MultiplatformLibraryPlugin : Plugin<Project> {
@@ -17,8 +15,6 @@ class MultiplatformLibraryPlugin : Plugin<Project> {
         apply("com.android.library")
       }
 
-      configureMultiplatformLibrary(kotlinExtension)
-
       (kotlinExtension as KotlinMultiplatformExtension).apply {
         applyDefaultHierarchyTemplate()
         androidTarget()
@@ -28,12 +24,4 @@ class MultiplatformLibraryPlugin : Plugin<Project> {
       configureKotlinAndroid(extension)
     }
   }
-}
-
-private fun configureMultiplatformLibrary(
-    commonExtension: KotlinProjectExtension,
-) {
-    commonExtension.jvmToolchain {
-      languageVersion.set(JavaLanguageVersion.of(17))
-    }
 }

--- a/build-logic/convention/src/main/kotlin/fr/androidmakers/plugin/MultiplatformLibraryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/fr/androidmakers/plugin/MultiplatformLibraryPlugin.kt
@@ -4,6 +4,7 @@ import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
@@ -18,6 +19,12 @@ class MultiplatformLibraryPlugin : Plugin<Project> {
       (kotlinExtension as KotlinMultiplatformExtension).apply {
         applyDefaultHierarchyTemplate()
         androidTarget()
+
+        jvm {
+          compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+          }
+        }
       }
 
       val extension = extensions.getByType<LibraryExtension>()

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -19,13 +19,13 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
     isCoreLibraryDesugaringEnabled = true
   }
 
   kotlinOptions {
-    jvmTarget = "1.8"
+    jvmTarget = "17"
   }
 
   buildTypes {


### PR DESCRIPTION
- Use target JDK 17 in all modules instead of a mix of versions
- Disable Gradle toolchain, use target JDK instead. Toolchains prevent from using more recent JDK versions to build the project
- Upgrade Github actions script to use JDK 21 to build the project and enable Gradle caching. The cache is written during the build that occurs after a branch has been merged in main
- Run the CI when the main branch is updated in addition to pull requests
- Disable the `:shared:linkDebugFrameworkIosArm64` task on the CI: it has no effect since the CI is configured to run on Ubuntu (Mac OS runners should only be used to create release builds anyway)
- Add CI badge in README.