### PR TITLE
fix: use the correct group reference when the CI is triggered during a push on the main branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ on:
 
 # Cancel any current or previous job from the same PR
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Sorry I forgot to fix this when enabling the CI on the main branch.
`github.head_ref` is only valid when the CI is triggered from a PR.