### PR TITLE
refactor: optimize the usage of Lce in ViewModels

### DIFF
--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/about/AboutViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/about/AboutViewModel.kt
@@ -13,6 +13,4 @@ class AboutViewModel(
     val openYoutube: OpenYoutubeUseCase,
     val openCoc: OpenCocUseCase,
     val openFaq: OpenFaqUseCase
-): ViewModel() {
-
-}
+): ViewModel()

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayoutViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayoutViewModel.kt
@@ -14,8 +14,8 @@ import moe.tlaster.precompose.viewmodel.ViewModel
 import moe.tlaster.precompose.viewmodel.viewModelScope
 
 data class AgendaLayoutState(
-    val rooms: List<Room> = emptyList(),
-    val sessionFilters: List<SessionFilter> = emptyList()
+  val rooms: List<Room> = emptyList(),
+  val sessionFilters: List<SessionFilter> = emptyList()
 )
 
 class AgendaLayoutViewModel(
@@ -26,12 +26,16 @@ class AgendaLayoutViewModel(
 
   val state: StateFlow<AgendaLayoutState> = combine(
     roomsRepository.getRooms()
-      .map { it.getOrNull() ?: emptyList() },
+      .map { it.getOrNull().orEmpty() },
     sessionFilters,
     ::AgendaLayoutState
-  ).stateIn(scope(), SharingStarted.WhileSubscribed(), AgendaLayoutState())
+  ).stateIn(
+    scope = scope(),
+    started = SharingStarted.Eagerly,
+    initialValue = AgendaLayoutState()
+  )
 
-  fun onFiltersChanged(sessionFilters: List<SessionFilter>) {
-    this.sessionFilters.value = sessionFilters
+  fun onFiltersChanged(newSessionFilters: List<SessionFilter>) {
+    sessionFilters.value = newSessionFilters
   }
 }

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPagerViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPagerViewModel.kt
@@ -8,25 +8,18 @@ import fr.androidmakers.domain.interactor.GetAgendaUseCase
 import fr.androidmakers.domain.interactor.GetFavoriteSessionsUseCase
 import fr.androidmakers.domain.interactor.SetSessionBookmarkUseCase
 import fr.androidmakers.domain.model.Agenda
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import moe.tlaster.precompose.viewmodel.viewModelScope
 
 class AgendaPagerViewModel(
-  private val getAgendaUseCase: GetAgendaUseCase,
+  getAgendaUseCase: GetAgendaUseCase,
   private val setSessionBookmarkUseCase: SetSessionBookmarkUseCase,
   private val getFavoriteSessionsUseCase: GetFavoriteSessionsUseCase,
   private val applyForAppClinicUseCase: ApplyForAppClinicUseCase,
-) : LceViewModel<Agenda>() {
-  override fun produce(): Flow<Result<Agenda>> {
-    return getAgendaUseCase()
-  }
-
+) : LceViewModel<Agenda>(
+  produce = { getAgendaUseCase() }
+) {
   fun getFavoriteSessions() = getFavoriteSessionsUseCase()
-
-  init {
-    launch(false)
-  }
 
   fun setSessionBookmark(uiSession: UISession, bookmark: Boolean) = viewModelScope.launch {
     setSessionBookmarkUseCase(uiSession.id, bookmark)

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/LceViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/LceViewModel.kt
@@ -1,51 +1,45 @@
 package com.androidmakers.ui.common
 
 import com.androidmakers.ui.model.Lce
-import kotlinx.coroutines.Job
+import com.androidmakers.ui.model.toLce
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import moe.tlaster.precompose.viewmodel.ViewModel
 import moe.tlaster.precompose.viewmodel.viewModelScope
 
 
-abstract class LceViewModel<T> : ViewModel() {
-  abstract fun produce(): Flow<Result<T>>
+abstract class LceViewModel<T>(
+  produce: () -> Flow<Result<T>>
+) : ViewModel() {
+  private val loadingTrigger = MutableStateFlow(0)
 
-  private val _mutableSharedState = MutableStateFlow<Lce<T>>(Lce.Loading)
-  val values = _mutableSharedState.asStateFlow()
+  @OptIn(ExperimentalCoroutinesApi::class)
+  val values: StateFlow<Lce<T>> = loadingTrigger.flatMapLatest {
+    produce()
+      .map { it.toLce() }
+      .onEach {
+        _isRefreshing.value = false
+      }
+  }.stateIn(
+    scope = viewModelScope,
+    started = SharingStarted.Eagerly,
+    initialValue = Lce.Loading
+  )
 
   private val _isRefreshing = MutableStateFlow(false)
   val isRefreshing = _isRefreshing.asStateFlow()
 
-  private var job: Job? = null
-
-  protected fun launch(isRefresh: Boolean) {
-    job?.cancel()
-    job = viewModelScope.launch {
-      produce().map {
-        it.fold(
-            onSuccess = { Lce.Content(it) },
-            onFailure = { Lce.Error }
-        )
-      }.onStart {
-        if (!isRefresh) {
-          emit(Lce.Loading)
-        }
-      }.collect {
-        _mutableSharedState.value = it
-        if (it != Lce.Loading) {
-          _isRefreshing.value = false
-        }
-      }
-    }
-  }
-
   fun refresh() {
     _isRefreshing.value = true
-    launch(true)
+    loadingTrigger.update { it + 1 }
   }
 }

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailViewModel.kt
@@ -1,6 +1,7 @@
 package com.androidmakers.ui.speakers
 
 import com.androidmakers.ui.model.Lce
+import com.androidmakers.ui.model.toLce
 import fr.androidmakers.domain.PlatformContext
 import fr.androidmakers.domain.interactor.OpenLinkUseCase
 import fr.androidmakers.domain.model.SocialsItem
@@ -14,31 +15,24 @@ import moe.tlaster.precompose.viewmodel.ViewModel
 import moe.tlaster.precompose.viewmodel.viewModelScope
 
 class SpeakerDetailsViewModel(
-    speakerId: String,
-    speakersRepository: SpeakersRepository,
+  speakerId: String,
+  speakersRepository: SpeakersRepository,
   private val openLinkUseCase: OpenLinkUseCase,
 ) : ViewModel() {
 
   val uiState: StateFlow<Lce<SpeakerDetailsUiState>> = speakersRepository
-      .getSpeaker(speakerId).map {
-        it.fold(
-          onSuccess = { speaker ->
-            Lce.Content(
-              SpeakerDetailsUiState(
-                speaker = speaker
-              )
-            )
-          },
-          onFailure = {
-            Lce.Error
-          }
+    .getSpeaker(speakerId).map { result ->
+      result.map {
+        SpeakerDetailsUiState(
+          speaker = it
         )
-      }
-      .stateIn(
-          scope = viewModelScope,
-          started = SharingStarted.WhileSubscribed(5000L),
-          initialValue = Lce.Loading
-      )
+      }.toLce()
+    }
+    .stateIn(
+      scope = viewModelScope,
+      started = SharingStarted.Eagerly,
+      initialValue = Lce.Loading
+    )
 
   fun openSpeakerLink(platformContext: PlatformContext, socialsItem: SocialsItem) {
     socialsItem.url?.let { openLinkUseCase(platformContext, it) }
@@ -46,5 +40,5 @@ class SpeakerDetailsViewModel(
 }
 
 data class SpeakerDetailsUiState(
-    val speaker: Speaker
+  val speaker: Speaker
 )

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerListViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerListViewModel.kt
@@ -1,6 +1,7 @@
 package com.androidmakers.ui.speakers
 
 import com.androidmakers.ui.model.Lce
+import com.androidmakers.ui.model.toLce
 import fr.androidmakers.domain.model.Speaker
 import fr.androidmakers.domain.repo.SpeakersRepository
 import kotlinx.coroutines.flow.Flow
@@ -11,19 +12,12 @@ class SpeakerListViewModel(
     speakersRepository: SpeakersRepository
 ) : ViewModel() {
 
-  val uiState: Flow<Lce<SpeakersUiState>> = speakersRepository.getSpeakers().map {
-    it.fold(
-      onSuccess = { speakers ->
-        Lce.Content(
-          SpeakersUiState(
-            speakers = speakers
-          )
-        )
-      },
-      onFailure = {
-        Lce.Error
-      }
-    )
+  val uiState: Flow<Lce<SpeakersUiState>> = speakersRepository.getSpeakers().map { result ->
+    result.map {
+      SpeakersUiState(
+        speakers = it
+      )
+    }.toLce()
   }
 }
 

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/sponsors/SponsorsViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/sponsors/SponsorsViewModel.kt
@@ -4,17 +4,10 @@ import com.androidmakers.ui.common.LceViewModel
 import fr.androidmakers.domain.interactor.GetPartnersUseCase
 import fr.androidmakers.domain.interactor.OpenPartnerLinkUseCase
 import fr.androidmakers.domain.model.PartnerGroup
-import kotlinx.coroutines.flow.Flow
 
 class SponsorsViewModel(
-    private val getPartnersUseCase: GetPartnersUseCase,
+    getPartnersUseCase: GetPartnersUseCase,
     val openPartnerLink: OpenPartnerLinkUseCase,
-) : LceViewModel<List<PartnerGroup>>() {
-  override fun produce(): Flow<Result<List<PartnerGroup>>> {
-    return getPartnersUseCase()
-  }
-
-  init {
-    launch(false)
-  }
-}
+) : LceViewModel<List<PartnerGroup>>(
+  produce = { getPartnersUseCase() }
+)


### PR DESCRIPTION
Also change the StateFlows sharing strategy to `SharingStarted.Eagerly` for all ViewModels because:
- All Flows loading data end immediately after emitting the result, so it's OK to keep subscribing to the StateFlow because it becomes "cold"
- Subscribers are currently not lifecycle-aware so the StateFlow always has subscribers, even when the screen is invisible.