### PR TITLE
refactor: migrate from PreCompose to JetBrains ViewModel and Navigation

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -76,10 +76,3 @@ dependencies {
   // Used for tags
   implementation(project(":shared"))
 }
-
-configurations.configureEach {
-  if (name.endsWith("RuntimeClasspath")) {
-    // See https://github.com/Tlaster/PreCompose/issues/317
-    exclude("androidx.compose.ui", "ui-test-junit4-android")
-  }
-}

--- a/androidApp/src/test/java/fr/paug/androidmakers/ui/components/AgendaLayoutViewModelTest.kt
+++ b/androidApp/src/test/java/fr/paug/androidmakers/ui/components/AgendaLayoutViewModelTest.kt
@@ -19,7 +19,7 @@ class AgendaLayoutViewModelTest {
 
   private val testSubject = AgendaLayoutViewModel(
     roomsRepository = fakeStore,
-    scope = { CoroutineScope(Dispatchers.Unconfined) }
+    coroutineScope = CoroutineScope(Dispatchers.Unconfined)
   )
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,8 @@ firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
 jetbrains-lifecycle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime", version.ref = "jetbrainsLifecycle" }
-jetbrains-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "jetbrainsLifecycle" }
+jetbrains-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "jetbrainsLifecycle" }
+jetbrains-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "jetbrainsLifecycle" }
 jetbrains-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "jetbrainsNavigation" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ googleid = "1.1.1"
 horologist = "0.6.22"
 jetbrainsCompose = "1.6.11"
 jetbrainsLifecycle = "2.8.4"
+jetbrainsNavigation = "2.7.0-alpha07"
 junit = "4.13.2"
 koin = "4.0.2"
 kotlin = "2.1.10"
@@ -35,7 +36,6 @@ okio = "3.10.2"
 openfeedback-m3 = "0.2.3"
 playServices-auth = "21.3.0"
 playServices-wearable = "19.0.0"
-precompose = "1.6.1"
 pullrefresh = "1.3.0"
 
 [libraries]
@@ -60,6 +60,8 @@ firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
 jetbrains-lifecycle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime", version.ref = "jetbrainsLifecycle" }
+jetbrains-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "jetbrainsLifecycle" }
+jetbrains-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "jetbrainsNavigation" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
@@ -74,11 +76,11 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhtt
 okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
 openfeedback-m3 = { module = "io.openfeedback:openfeedback-m3", version.ref = "openfeedback-m3" }
 play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServices-auth" }
-precompose = { module = "moe.tlaster:precompose", version.ref = "precompose" }
-precompose-koin = { module = "moe.tlaster:precompose-koin", version.ref = "precompose" }
-precompose-viewmodel = { module = "moe.tlaster:precompose-viewmodel", version.ref = "precompose" }
 
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
+koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -26,8 +26,6 @@ kotlin {
     commonMain.dependencies {
       api(libs.moko.resources)
 
-      // Temporary
-      api(libs.precompose.koin)
       api(project(":shared:ui"))
       api(project(":shared:domain"))
       api(project(":shared:di"))

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 }
 
 configurations.configureEach {
-  // Remove unnecessary dependency of Precompose and Moko
+  // Remove unnecessary dependency of Moko
   exclude(group = "androidx.appcompat", module = "appcompat")
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
 
   sourceSets {
     commonMain.dependencies {
-      api(libs.moko.resources)
+      implementation(libs.moko.resources)
 
       api(project(":shared:ui"))
       api(project(":shared:domain"))

--- a/shared/di/build.gradle.kts
+++ b/shared/di/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
 
   sourceSets {
     androidMain.dependencies {
-      implementation(libs.koin.androidx.compose)
+      implementation(libs.koin.android)
     }
 
     commonMain.dependencies {
@@ -32,7 +32,7 @@ kotlin {
 }
 
 configurations.configureEach {
-  // Remove unnecessary dependency of Precompose
+  // Remove unnecessary dependency of Precompose and Koin Android
   exclude(group = "androidx.appcompat", module = "appcompat")
 }
 

--- a/shared/ui/build.gradle.kts
+++ b/shared/ui/build.gradle.kts
@@ -54,7 +54,7 @@ kotlin {
 }
 
 configurations.configureEach {
-  // Remove unnecessary dependency of Precompose and Moko
+  // Remove unnecessary dependency of Moko
   exclude(group = "androidx.appcompat", module = "appcompat")
   // Disable Android Drawable support in Coil
   exclude(group = "com.google.accompanist", module = "accompanist-drawablepainter")

--- a/shared/ui/build.gradle.kts
+++ b/shared/ui/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
 
   sourceSets {
     commonMain.dependencies {
-      api(libs.moko.resources.compose)
+      implementation(libs.moko.resources.compose)
       implementation(compose.runtime)
       implementation(compose.foundation)
       implementation(compose.material3)
@@ -29,11 +29,12 @@ kotlin {
       implementation(compose.components.resources)
       implementation(compose.materialIconsExtended)
       implementation(compose.components.uiToolingPreview)
-      api(libs.coil.compose)
-      api(libs.jetbrains.navigation.compose)
-      api(libs.jetbrains.lifecycle.viewmodel)
-      api(libs.koin.compose)
-      api(libs.koin.compose.viewmodel)
+      implementation(libs.coil.compose)
+      implementation(libs.jetbrains.navigation.compose)
+      implementation(libs.jetbrains.lifecycle.runtime.compose)
+      implementation(libs.jetbrains.lifecycle.viewmodel.compose)
+      implementation(libs.koin.compose)
+      implementation(libs.koin.compose.viewmodel)
       api(libs.openfeedback.m3)
       implementation(libs.kotlinx.coroutines.core)
       implementation(libs.okio)   // Used by Openfeedback

--- a/shared/ui/build.gradle.kts
+++ b/shared/ui/build.gradle.kts
@@ -30,9 +30,10 @@ kotlin {
       implementation(compose.materialIconsExtended)
       implementation(compose.components.uiToolingPreview)
       api(libs.coil.compose)
-      api(libs.precompose)
-      api(libs.precompose.viewmodel)
-      api(libs.precompose.koin)
+      api(libs.jetbrains.navigation.compose)
+      api(libs.jetbrains.lifecycle.viewmodel)
+      api(libs.koin.compose)
+      api(libs.koin.compose.viewmodel)
       api(libs.openfeedback.m3)
       implementation(libs.kotlinx.coroutines.core)
       implementation(libs.okio)   // Used by Openfeedback

--- a/shared/ui/src/androidMain/kotlin/com/androidmakers/ui/MainLayout.android.kt
+++ b/shared/ui/src/androidMain/kotlin/com/androidmakers/ui/MainLayout.android.kt
@@ -1,11 +1,19 @@
 package com.androidmakers.ui
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import fr.androidmakers.domain.PlatformContext
-import moe.tlaster.precompose.navigation.transition.NavTransition
 
-actual val defaultTransition: NavTransition = NavTransition()
+actual val defaultEnterTransition: EnterTransition = fadeIn() + scaleIn(initialScale = 0.9f)
+actual val defaultExitTransition: ExitTransition = fadeOut() + scaleOut(targetScale = 1.1f)
+actual val defaultPopEnterTransition: EnterTransition = fadeIn() + scaleIn(initialScale = 1.1f)
+actual val defaultPopExitTransition: ExitTransition = fadeOut() + scaleOut(targetScale = 0.9f)
 
 @Composable
 actual fun getPlatformContext(): PlatformContext = PlatformContext(LocalContext.current)

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/about/AboutScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/about/AboutScreen.kt
@@ -31,14 +31,14 @@ import com.androidmakers.ui.getPlatformContext
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
 import fr.paug.androidmakers.ui.MR
-import moe.tlaster.precompose.koin.koinViewModel
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun AboutScreen(
     versionName: String,
     versionCode: String,
 ) {
-  val viewModel = koinViewModel(vmClass = AboutViewModel::class)
+  val viewModel = koinViewModel<AboutViewModel>()
   Column(
       modifier = Modifier
           .fillMaxSize()

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/about/AboutViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/about/AboutViewModel.kt
@@ -1,11 +1,11 @@
 package com.androidmakers.ui.about
 
+import androidx.lifecycle.ViewModel
 import fr.androidmakers.domain.interactor.OpenCocUseCase
 import fr.androidmakers.domain.interactor.OpenFaqUseCase
 import fr.androidmakers.domain.interactor.OpenXAccountUseCase
 import fr.androidmakers.domain.interactor.OpenXHashtagUseCase
 import fr.androidmakers.domain.interactor.OpenYoutubeUseCase
-import moe.tlaster.precompose.viewmodel.ViewModel
 
 class AboutViewModel(
     val openXAccount: OpenXAccountUseCase,

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayout.kt
@@ -37,15 +37,15 @@ import fr.androidmakers.domain.utils.eventTimeZone
 import fr.paug.androidmakers.ui.MR
 import kotlinx.datetime.Clock
 import kotlinx.datetime.todayIn
-import moe.tlaster.precompose.koin.koinViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun AgendaLayout(
     agendaFilterDrawerState: DrawerState,
     onSessionClick: (sessionId: String) -> Unit,
 ) {
-  val agendaLayoutViewModel = koinViewModel(vmClass = AgendaLayoutViewModel::class)
+  val agendaLayoutViewModel = koinViewModel<AgendaLayoutViewModel>()
   val agendaLayoutState by agendaLayoutViewModel.state.collectAsState()
 
   ModalNavigationDrawer(

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayout.kt
@@ -75,7 +75,7 @@ private fun AgendaPagerOrLoading(
     sessionFilters: List<SessionFilter>,
     onSessionClick: (sessionId: String) -> Unit,
 ) {
-  val viewModel = koinViewModel(vmClass = AgendaPagerViewModel::class)
+  val viewModel = koinViewModel<AgendaPagerViewModel>()
   ButtonRefreshableLceLayout(viewModel) { daySchedules ->
     AgendaPager(
         initialPageIndex = daySchedules.todayPageIndex(),

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayoutViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayoutViewModel.kt
@@ -18,19 +18,33 @@ data class AgendaLayoutState(
   val sessionFilters: List<SessionFilter> = emptyList()
 )
 
-class AgendaLayoutViewModel(
-    roomsRepository: RoomsRepository,
-    scope: ViewModel.() -> CoroutineScope = { viewModelScope }
-) : ViewModel() {
+class AgendaLayoutViewModel : ViewModel {
   private val sessionFilters = MutableStateFlow(emptyList<SessionFilter>())
 
-  val state: StateFlow<AgendaLayoutState> = combine(
+  val state: StateFlow<AgendaLayoutState>
+
+  constructor(
+    roomsRepository: RoomsRepository
+  ) : super() {
+    state = createState(roomsRepository)
+  }
+
+  constructor(
+    roomsRepository: RoomsRepository,
+    coroutineScope: CoroutineScope
+  ) : super(coroutineScope) {
+    state = createState(roomsRepository)
+  }
+
+  private fun createState(
+    roomsRepository: RoomsRepository
+  ): StateFlow<AgendaLayoutState> = combine(
     roomsRepository.getRooms()
       .map { it.getOrNull().orEmpty() },
     sessionFilters,
     ::AgendaLayoutState
   ).stateIn(
-    scope = scope(),
+    scope = viewModelScope,
     started = SharingStarted.Eagerly,
     initialValue = AgendaLayoutState()
   )

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayoutViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayoutViewModel.kt
@@ -1,5 +1,7 @@
 package com.androidmakers.ui.agenda
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.androidmakers.ui.common.SessionFilter
 import fr.androidmakers.domain.model.Room
 import fr.androidmakers.domain.repo.RoomsRepository
@@ -10,8 +12,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import moe.tlaster.precompose.viewmodel.ViewModel
-import moe.tlaster.precompose.viewmodel.viewModelScope
 
 data class AgendaLayoutState(
   val rooms: List<Room> = emptyList(),

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPager.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPager.kt
@@ -19,8 +19,7 @@ import com.androidmakers.ui.getPlatformContext
 import com.androidmakers.ui.model.UISession
 import fr.androidmakers.domain.utils.formatShortTime
 import kotlinx.coroutines.launch
-import moe.tlaster.precompose.koin.koinViewModel
-
+import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -65,7 +64,7 @@ fun AgendaPager(
     HorizontalPager(
         state = pagerState,
     ) { page ->
-      val viewModel = koinViewModel(vmClass = AgendaPagerViewModel::class)
+      val viewModel = koinViewModel<AgendaPagerViewModel>()
       SwipeRefreshableLceLayout(viewModel = viewModel) { daySchedules ->
         val sessions = daySchedules[page].sessions.filter(filterList)
         if (sessions.isEmpty()) {

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPager.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPager.kt
@@ -65,7 +65,7 @@ fun AgendaPager(
         state = pagerState,
     ) { page ->
       val viewModel = koinViewModel<AgendaPagerViewModel>()
-      SwipeRefreshableLceLayout(viewModel = viewModel) { daySchedules ->
+      SwipeRefreshableLceLayout(viewModel) { daySchedules ->
         val sessions = daySchedules[page].sessions.filter(filterList)
         if (sessions.isEmpty()) {
           EmptyLayout()

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPagerViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPagerViewModel.kt
@@ -1,5 +1,6 @@
 package com.androidmakers.ui.agenda
 
+import androidx.lifecycle.viewModelScope
 import com.androidmakers.ui.common.LceViewModel
 import com.androidmakers.ui.model.UISession
 import fr.androidmakers.domain.PlatformContext
@@ -9,7 +10,6 @@ import fr.androidmakers.domain.interactor.SetSessionBookmarkUseCase
 import fr.androidmakers.domain.repo.BookmarksRepository
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import moe.tlaster.precompose.viewmodel.viewModelScope
 
 class AgendaPagerViewModel(
   getAgendaUseCase: GetAgendaUseCase,

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailViewModel.kt
@@ -1,5 +1,7 @@
 package com.androidmakers.ui.agenda
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.androidmakers.ui.model.Lce
 import com.androidmakers.ui.model.SessionDetailState
 import fr.androidmakers.domain.PlatformContext
@@ -26,8 +28,6 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
-import moe.tlaster.precompose.viewmodel.ViewModel
-import moe.tlaster.precompose.viewmodel.viewModelScope
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SessionDetailViewModel(

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/LceViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/LceViewModel.kt
@@ -1,5 +1,7 @@
 package com.androidmakers.ui.common
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.androidmakers.ui.model.Lce
 import com.androidmakers.ui.model.toLce
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -13,8 +15,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import moe.tlaster.precompose.viewmodel.ViewModel
-import moe.tlaster.precompose.viewmodel.viewModelScope
 
 abstract class LceViewModel<T>(
   produce: () -> Flow<Result<T>>

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/AVALayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/AVALayout.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -220,14 +221,14 @@ private fun RowScope.NavigationBarItem(
 //          disabledTextColor =
       ),
       onClick = {
-        if (currentRoute != destinationRoute.name) {
-          if (destinationRoute == AVANavigationRoute.AGENDA) {
-            avaNavController.popBackStack()
-          } else {
-            avaNavController.navigate(destinationRoute.name) {
-              popUpTo(AVANavigationRoute.AGENDA.name)
+        avaNavController.navigate(destinationRoute.name) {
+          avaNavController.graph.findStartDestination().route?.let { startRoute ->
+            popUpTo(startRoute) {
+              saveState = true
             }
           }
+          launchSingleTop = true
+          restoreState = true
         }
       }
   )

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailViewModel.kt
@@ -1,5 +1,7 @@
 package com.androidmakers.ui.speakers
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.androidmakers.ui.model.Lce
 import com.androidmakers.ui.model.toLce
 import fr.androidmakers.domain.PlatformContext
@@ -11,8 +13,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import moe.tlaster.precompose.viewmodel.ViewModel
-import moe.tlaster.precompose.viewmodel.viewModelScope
 
 class SpeakerDetailsViewModel(
   speakerId: String,

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerListViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerListViewModel.kt
@@ -1,12 +1,12 @@
 package com.androidmakers.ui.speakers
 
+import androidx.lifecycle.ViewModel
 import com.androidmakers.ui.model.Lce
 import com.androidmakers.ui.model.toLce
 import fr.androidmakers.domain.model.Speaker
 import fr.androidmakers.domain.repo.SpeakersRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import moe.tlaster.precompose.viewmodel.ViewModel
 
 class SpeakerListViewModel(
     speakersRepository: SpeakersRepository

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/sponsors/SponsorScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/sponsors/SponsorScreen.kt
@@ -1,6 +1,5 @@
 package com.androidmakers.ui.sponsors
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
@@ -26,11 +25,11 @@ import com.androidmakers.ui.getPlatformContext
 import com.androidmakers.ui.model.Lce
 import fr.androidmakers.domain.model.Partner
 import fr.androidmakers.domain.model.PartnerGroup
-import moe.tlaster.precompose.koin.koinViewModel
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun SponsorsScreen() {
-  val viewModel = koinViewModel(SponsorsViewModel::class)
+  val viewModel = koinViewModel<SponsorsViewModel>()
   val sponsors by viewModel.values.collectAsState()
   val platformContext = getPlatformContext()
 

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/theme/AndroidMakersTheme.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/theme/AndroidMakersTheme.kt
@@ -1,21 +1,9 @@
-@file:OptIn(ExperimentalResourceApi::class, ExperimentalResourceApi::class, ExperimentalResourceApi::class, ExperimentalResourceApi::class)
-
 package com.androidmakers.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
-import dev.icerock.moko.resources.compose.fontFamilyResource
-import fr.paug.androidmakers.ui.MR
-import moe.tlaster.precompose.PreComposeApp
-import org.jetbrains.compose.resources.ExperimentalResourceApi
-
-
 
 // TODO to be changed
 object AMColor {
@@ -27,26 +15,23 @@ object AMColor {
 
 @Composable
 fun AndroidMakersTheme(
-    useDarkTheme: Boolean = isSystemInDarkTheme(),
-    content: @Composable () -> Unit
+  useDarkTheme: Boolean = isSystemInDarkTheme(),
+  content: @Composable () -> Unit
 ) {
-
   val colorSchemeColors = if (!useDarkTheme) LightDefaultColorScheme else DarkDefaultColorScheme
-    PreComposeApp {
-      MaterialTheme(
-          colorScheme = colorSchemeColors,
-          typography = androidMakersTypography(),
-          content = content,
-      )
-    }
+  MaterialTheme(
+    colorScheme = colorSchemeColors,
+    typography = androidMakersTypography(),
+    content = content,
+  )
 }
 
 class AMAlphas(
-    val small: Float,
-    val big: Float
+  val small: Float,
+  val big: Float
 )
 
 val AMAlpha = AMAlphas(
-    15f / 255,
-    50f / 255
+  15f / 255,
+  50f / 255
 )

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/venue/VenuePager.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/venue/VenuePager.kt
@@ -24,13 +24,12 @@ import dev.icerock.moko.resources.compose.stringResource
 import fr.paug.androidmakers.ui.MR
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import moe.tlaster.precompose.koin.koinViewModel
-
+import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun VenuePager() {
-  val viewModel = koinViewModel(VenueViewModel::class)
+  val viewModel = koinViewModel<VenueViewModel>()
 
   Column(modifier = Modifier.fillMaxWidth()) {
 

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/venue/VenueViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/venue/VenueViewModel.kt
@@ -1,10 +1,9 @@
 package com.androidmakers.ui.venue
 
+import androidx.lifecycle.ViewModel
 import fr.androidmakers.domain.interactor.GetAfterpartyVenueUseCase
 import fr.androidmakers.domain.interactor.GetConferenceVenueUseCase
 import fr.androidmakers.domain.interactor.OpenMapUseCase
-import moe.tlaster.precompose.viewmodel.ViewModel
-
 
 class VenueViewModel(
     val getConferenceVenueUseCase: GetConferenceVenueUseCase,

--- a/shared/ui/src/iosMain/kotlin/com/androidmakers/ui/MainLayout.ios.kt
+++ b/shared/ui/src/iosMain/kotlin/com/androidmakers/ui/MainLayout.ios.kt
@@ -1,18 +1,16 @@
 package com.androidmakers.ui
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.runtime.Composable
 import fr.androidmakers.domain.PlatformContext
-import moe.tlaster.precompose.navigation.transition.NavTransition
 
-actual val defaultTransition: NavTransition = NavTransition(
-  createTransition = slideInHorizontally { it },
-  pauseTransition = slideOutHorizontally { -it / 4 },
-  destroyTransition = slideOutHorizontally { it },
-  resumeTransition = slideInHorizontally { -it / 4 },
-  exitTargetContentZIndex = 1f
-)
+actual val defaultEnterTransition: EnterTransition = slideInHorizontally(initialOffsetX = { it })
+actual val defaultExitTransition: ExitTransition = slideOutHorizontally(targetOffsetX = { -it / 4 })
+actual val defaultPopEnterTransition: EnterTransition = slideInHorizontally(initialOffsetX = { -it / 4 })
+actual val defaultPopExitTransition: ExitTransition = slideOutHorizontally(targetOffsetX = { it })
 
 @Composable
 actual fun getPlatformContext(): PlatformContext = PlatformContext

--- a/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/signin/SignInScreen.kt
+++ b/wearApp/src/main/java/fr/paug/androidmakers/wear/ui/signin/SignInScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.Modifier
 import com.google.android.horologist.auth.composables.dialogs.SignedInConfirmationDialog
 import com.google.android.horologist.auth.composables.screens.AuthErrorScreen
 import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
-import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInViewModel
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import org.koin.androidx.compose.koinViewModel
 
@@ -27,7 +26,7 @@ fun SignInScreen(
         failedContent = {
           AuthErrorScreen()
         },
-        viewModel = koinViewModel<GoogleSignInViewModel>()
+        viewModel = koinViewModel()
     ) { successState ->
       SignedInConfirmationDialog(
           modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
Also change the behavior of the main bottom navigation:
- Navigating back switches back to the first bottom navigation destination instead of leaving the app
- The state of each main bottom navigation destination is saved and restored when switching between destinations (it's not saved when navigating back).