### PR TITLE
refactor: change cache policy during manual refresh

### DIFF
--- a/androidApp/src/test/java/fr/paug/androidmakers/fixtures/FakeAndroidMakersStore.kt
+++ b/androidApp/src/test/java/fr/paug/androidmakers/fixtures/FakeAndroidMakersStore.kt
@@ -17,7 +17,7 @@ class FakeAndroidMakersStore : RoomsRepository, VenueRepository, SpeakersReposit
   SessionsRepository, PartnersRepository {
   val roomsMutableFlow = MutableStateFlow(Result.success(emptyList<Room>()))
 
-  override fun getRooms(): Flow<Result<List<Room>>> = roomsMutableFlow
+  override fun getRooms(refresh: Boolean): Flow<Result<List<Room>>> = roomsMutableFlow
 
   override fun getVenue(id: String): Flow<Result<Venue>> {
     TODO("Not yet implemented")
@@ -39,11 +39,11 @@ class FakeAndroidMakersStore : RoomsRepository, VenueRepository, SpeakersReposit
     TODO("Not yet implemented")
   }
 
-  override fun getSessions(): Flow<Result<List<Session>>> {
+  override fun getSessions(refresh: Boolean): Flow<Result<List<Session>>> {
     TODO("Not yet implemented")
   }
 
-  override fun getSpeakers(): Flow<Result<List<Speaker>>> {
+  override fun getSpeakers(refresh: Boolean): Flow<Result<List<Speaker>>> {
     TODO("Not yet implemented")
   }
 

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/ApolloExtensions.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/ApolloExtensions.kt
@@ -20,11 +20,13 @@ internal fun <T : Operation.Data> Flow<ApolloResponse<T>>.ignoreCacheMisses(): F
 }
 
 
-internal fun <T : Operation.Data> ApolloCall<T>.cacheAndNetwork(): Flow<Result<T>> {
+internal fun <T : Operation.Data> ApolloCall<T>.cacheAndNetwork(
+  refresh: Boolean = false
+): Flow<Result<T>> {
   return flow {
     var hasData = false
     var exception: ApolloException? = null
-    fetchPolicy(FetchPolicy.CacheAndNetwork)
+    fetchPolicy(if (refresh) FetchPolicy.NetworkFirst else FetchPolicy.CacheAndNetwork)
       .toFlow()
       .collect {
         val data = it.data

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/PartnersGraphQLRepository.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/PartnersGraphQLRepository.kt
@@ -11,9 +11,9 @@ class PartnersGraphQLRepository(private val apolloClient: ApolloClient): Partner
   override fun getPartners(): Flow<Result<List<PartnerGroup>>> {
     return apolloClient.query(GetPartnerGroupsQuery())
         .cacheAndNetwork()
-        .map {
-          it.map {
-            it.partnerGroups.map { partnerGroup ->
+        .map { dataResult ->
+          dataResult.map { data ->
+            data.partnerGroups.map { partnerGroup ->
               PartnerGroup(
                 title = partnerGroup.title,
                 partners = partnerGroup.partners.map { partner ->

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/RoomsGraphQLRepository.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/RoomsGraphQLRepository.kt
@@ -8,11 +8,14 @@ import kotlinx.coroutines.flow.map
 
 class RoomsGraphQLRepository(private val apolloClient: ApolloClient) : RoomsRepository {
   override fun getRoom(id: String): Flow<Result<Room>> {
-    return getRooms(false).map { roomsResult ->
-      roomsResult.mapCatching { rooms ->
-        rooms.firstOrNull { it.id == id } ?: error("Room not found")
+    return apolloClient.query(GetRoomsQuery())
+      .cacheAndNetwork()
+      .map { dataResult ->
+        dataResult.mapCatching { data ->
+          data.rooms.firstOrNull { it.roomDetails.id == id }?.roomDetails?.toRoom()
+            ?: error("Room not found")
+        }
       }
-    }
   }
 
   override fun getRooms(refresh: Boolean): Flow<Result<List<Room>>> {

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/RoomsGraphQLRepository.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/RoomsGraphQLRepository.kt
@@ -6,16 +6,22 @@ import fr.androidmakers.domain.repo.RoomsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class RoomsGraphQLRepository(private val apolloClient: ApolloClient): RoomsRepository {
+class RoomsGraphQLRepository(private val apolloClient: ApolloClient) : RoomsRepository {
   override fun getRoom(id: String): Flow<Result<Room>> {
-    return getRooms().map {
-      it.map { it.singleOrNull { it.id == id } ?: error("Not Room") }
+    return getRooms(false).map { roomsResult ->
+      roomsResult.mapCatching { rooms ->
+        rooms.firstOrNull { it.id == id } ?: error("Room not found")
+      }
     }
   }
 
-  override fun getRooms(): Flow<Result<List<Room>>> {
+  override fun getRooms(refresh: Boolean): Flow<Result<List<Room>>> {
     return apolloClient.query(GetRoomsQuery())
-        .cacheAndNetwork()
-        .map { it.map { it.rooms.map { it.roomDetails.toRoom() } } }
+      .cacheAndNetwork(refresh)
+      .map { dataResult ->
+        dataResult.map { data ->
+          data.rooms.map { it.roomDetails.toRoom() }
+        }
+      }
   }
 }

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/SpeakersGraphQLRepository.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/SpeakersGraphQLRepository.kt
@@ -21,10 +21,13 @@ class SpeakersGraphQLRepository(private val apolloClient: ApolloClient) : Speake
   }
 
   override fun getSpeaker(id: String): Flow<Result<Speaker>> {
-    return getSpeakers(false).map { speakersResult ->
-      speakersResult.mapCatching { speakers ->
-        speakers.firstOrNull { it.id == id } ?: error("Speaker not found")
+    return apolloClient.query(GetSpeakersQuery())
+      .cacheAndNetwork()
+      .map { dataResult ->
+        dataResult.mapCatching { data ->
+          data.speakers.firstOrNull { it.speakerDetails.id == id }?.speakerDetails?.toSpeaker()
+            ?: error("Speaker not found")
+        }
       }
-    }
   }
 }

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/VenueGraphQLRepository.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/VenueGraphQLRepository.kt
@@ -6,10 +6,14 @@ import fr.androidmakers.domain.repo.VenueRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class VenueGraphQLRepository(private val apolloClient: ApolloClient): VenueRepository {
+class VenueGraphQLRepository(private val apolloClient: ApolloClient) : VenueRepository {
   override fun getVenue(id: String): Flow<Result<Venue>> {
     return apolloClient.query(GetVenueQuery(id))
-        .cacheAndNetwork()
-        .map { it.map { it.venue.toVenue() } }
+      .cacheAndNetwork()
+      .map { dataResult ->
+        dataResult.map { data ->
+          data.venue.toVenue()
+        }
+      }
   }
 }

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/GetAgendaUseCase.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/GetAgendaUseCase.kt
@@ -12,11 +12,11 @@ class GetAgendaUseCase(
     private val speakersRepository: SpeakersRepository,
     private val roomsRepository: RoomsRepository,
 ) {
-  operator fun invoke(): Flow<Result<Agenda>> {
+  operator fun invoke(refresh: Boolean): Flow<Result<Agenda>> {
     return combine(
-        sessionsRepository.getSessions(),
-        roomsRepository.getRooms(),
-        speakersRepository.getSpeakers(),
+        sessionsRepository.getSessions(refresh),
+        roomsRepository.getRooms(refresh),
+        speakersRepository.getSpeakers(refresh),
     ) { sessionsResult, roomsResult, speakersResult ->
 
       val sessions = sessionsResult.getOrElse {

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/RoomsRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/RoomsRepository.kt
@@ -7,5 +7,5 @@ interface RoomsRepository {
 
   fun getRoom(id: String): Flow<Result<Room>>
 
-  fun getRooms(): Flow<Result<List<Room>>>
+  fun getRooms(refresh: Boolean): Flow<Result<List<Room>>>
 }

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/SessionsRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/SessionsRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface SessionsRepository {
   fun getSession(id: String): Flow<Result<Session>>
 
-  fun getSessions(): Flow<Result<List<Session>>>
+  fun getSessions(refresh: Boolean): Flow<Result<List<Session>>>
 
   fun getBookmarks(userId: String): Flow<Result<Set<String>>>
 

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/SpeakersRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/SpeakersRepository.kt
@@ -7,5 +7,5 @@ interface SpeakersRepository {
 
   fun getSpeaker(id: String): Flow<Result<Speaker>>
 
-  fun getSpeakers(): Flow<Result<List<Speaker>>>
+  fun getSpeakers(refresh: Boolean): Flow<Result<List<Speaker>>>
 }

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayout.kt
@@ -52,8 +52,8 @@ fun AgendaLayout(
       drawerState = agendaFilterDrawerState,
       drawerContent = {
         ModalDrawerSheet(
-            drawerContainerColor = MaterialTheme.colorScheme.background,
-            drawerContentColor = MaterialTheme.colorScheme.onBackground,
+            drawerContainerColor = MaterialTheme.colorScheme.surface,
+            drawerContentColor = MaterialTheme.colorScheme.onSurface,
             drawerShape = RectangleShape,
             windowInsets = WindowInsets(0, 0, 0, 0),
         ) {

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayoutViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayoutViewModel.kt
@@ -39,7 +39,7 @@ class AgendaLayoutViewModel : ViewModel {
   private fun createState(
     roomsRepository: RoomsRepository
   ): StateFlow<AgendaLayoutState> = combine(
-    roomsRepository.getRooms()
+    roomsRepository.getRooms(false)
       .map { it.getOrNull().orEmpty() },
     sessionFilters,
     ::AgendaLayoutState

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPagerViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaPagerViewModel.kt
@@ -17,8 +17,8 @@ class AgendaPagerViewModel(
   bookmarksRepository: BookmarksRepository,
   private val applyForAppClinicUseCase: ApplyForAppClinicUseCase,
 ) : LceViewModel<List<DaySchedule>>(
-  produce = {
-    getAgendaUseCase()
+  produce = { refresh ->
+    getAgendaUseCase(refresh)
       .combine(bookmarksRepository.favoriteSessions) { agendaResult, favoriteSessions ->
         agendaResult.map { agenda -> agendaToDays(agenda, favoriteSessions) }
       }

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerListViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerListViewModel.kt
@@ -12,13 +12,14 @@ class SpeakerListViewModel(
     speakersRepository: SpeakersRepository
 ) : ViewModel() {
 
-  val uiState: Flow<Lce<SpeakersUiState>> = speakersRepository.getSpeakers().map { result ->
-    result.map {
-      SpeakersUiState(
-        speakers = it
-      )
-    }.toLce()
-  }
+  val uiState: Flow<Lce<SpeakersUiState>> = speakersRepository.getSpeakers(false)
+    .map { result ->
+      result.map {
+        SpeakersUiState(
+          speakers = it
+        )
+      }.toLce()
+    }
 }
 
 data class SpeakersUiState(


### PR DESCRIPTION
Add a `refresh` boolean argument to use cases to allow changing the cache policy during refresh and attempt to load from network first instead of cache first.

Currently the refresh indicator is hidden when the cache response arrives before the network response which is not accurate because the refresh is still in progress.
This change allows the refresh indicator to be accurate and only hide after the network query completes (with success or error). In case of error, the cache response will be pushed instead if available.