### PR TITLE
refactor: optimize loading in SessionDetailViewModel

### DIFF
--- a/androidApp/src/test/java/fr/paug/androidmakers/fixtures/FakeAndroidMakersStore.kt
+++ b/androidApp/src/test/java/fr/paug/androidmakers/fixtures/FakeAndroidMakersStore.kt
@@ -23,10 +23,6 @@ class FakeAndroidMakersStore : RoomsRepository, VenueRepository, SpeakersReposit
     TODO("Not yet implemented")
   }
 
-  override fun getSpeaker(id: String): Flow<Result<Speaker>> {
-    TODO("Not yet implemented")
-  }
-
   override fun getRoom(id: String): Flow<Result<Room>> {
     TODO("Not yet implemented")
   }
@@ -44,6 +40,14 @@ class FakeAndroidMakersStore : RoomsRepository, VenueRepository, SpeakersReposit
   }
 
   override fun getSpeakers(refresh: Boolean): Flow<Result<List<Speaker>>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getSpeaker(id: String): Flow<Result<Speaker>> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getSpeakers(ids: List<String>): Flow<Result<List<Speaker>>> {
     TODO("Not yet implemented")
   }
 

--- a/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/SpeakersGraphQLRepository.kt
+++ b/shared/data/src/commonMain/kotlin/fr/androidmakers/store/graphql/SpeakersGraphQLRepository.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo.ApolloClient
 import fr.androidmakers.domain.model.Speaker
 import fr.androidmakers.domain.repo.SpeakersRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 class SpeakersGraphQLRepository(private val apolloClient: ApolloClient) : SpeakersRepository {
@@ -26,7 +27,24 @@ class SpeakersGraphQLRepository(private val apolloClient: ApolloClient) : Speake
       .map { dataResult ->
         dataResult.mapCatching { data ->
           data.speakers.firstOrNull { it.speakerDetails.id == id }?.speakerDetails?.toSpeaker()
-            ?: error("Speaker not found")
+            ?: error("Speaker with id $id not found")
+        }
+      }
+  }
+
+  override fun getSpeakers(ids: List<String>): Flow<Result<List<Speaker>>> {
+    if (ids.isEmpty()) {
+      return flowOf(Result.success(emptyList()))
+    }
+    return apolloClient.query(GetSpeakersQuery())
+      .cacheAndNetwork(false)
+      .map { dataResult ->
+        dataResult.mapCatching { data ->
+          val speakersDataById = data.speakers.associateBy { it.speakerDetails.id }
+          ids.map { id ->
+            val speakerData = speakersDataById[id] ?: error("Speaker with id $id not found")
+            speakerData.speakerDetails.toSpeaker()
+          }
         }
       }
   }

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/SpeakersRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/repo/SpeakersRepository.kt
@@ -5,7 +5,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface SpeakersRepository {
 
+  fun getSpeakers(refresh: Boolean): Flow<Result<List<Speaker>>>
+
   fun getSpeaker(id: String): Flow<Result<Speaker>>
 
-  fun getSpeakers(refresh: Boolean): Flow<Result<List<Speaker>>>
+  fun getSpeakers(ids: List<String>): Flow<Result<List<Speaker>>>
 }

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailLayout.kt
@@ -74,9 +74,7 @@ fun SessionDetailScreen(
   viewModel: SessionDetailViewModel,
   onBackClick: () -> Unit,
 ) {
-  val sessionDetailState by viewModel.sessionDetailState.collectAsState(
-    initial = Lce.Loading
-  )
+  val sessionDetailState by viewModel.sessionDetailState.collectAsState()
   val platformContext = getPlatformContext()
 
   SessionDetailLayout(
@@ -161,7 +159,7 @@ fun SessionDetailLayout(
         is Lce.Loading, Lce.Error -> LoadingLayout()
         is Lce.Content -> SessionDetails(
           sessionDetails = sessionDetailState.content,
-          formattedDateAndRoom = sessionDetailState.content.formattedDateAndRoom(),
+          formattedDateAndRoom = sessionDetailState.content.formattedDateAndRoom,
           openLink = onOpenLink,
           onApplyForAppClinic = onApplyForAppClinic,
           modifier = Modifier.padding(innerPadding)

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailViewModel.kt
@@ -9,22 +9,18 @@ import fr.androidmakers.domain.interactor.ApplyForAppClinicUseCase
 import fr.androidmakers.domain.interactor.OpenLinkUseCase
 import fr.androidmakers.domain.interactor.SetSessionBookmarkUseCase
 import fr.androidmakers.domain.interactor.ShareSessionUseCase
-import fr.androidmakers.domain.model.Room
-import fr.androidmakers.domain.model.Session
 import fr.androidmakers.domain.model.SocialsItem
-import fr.androidmakers.domain.model.Speaker
 import fr.androidmakers.domain.repo.BookmarksRepository
 import fr.androidmakers.domain.repo.RoomsRepository
 import fr.androidmakers.domain.repo.SessionsRepository
 import fr.androidmakers.domain.repo.SpeakersRepository
-import fr.androidmakers.domain.utils.formatTimeInterval
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flatMapConcat
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
@@ -42,72 +38,55 @@ class SessionDetailViewModel(
     private val applyForAppClinicUseCase: ApplyForAppClinicUseCase,
 ) : ViewModel() {
 
-  private val session: Flow<Result<Session>> = sessionsRepository.getSession(sessionId)
-  private val room: Flow<Result<Room>> = session.flatMapConcat{ result ->
-    result.fold(
-      onSuccess = { roomsRepository.getRoom(it.roomId) },
-      onFailure = { flowOf(Result.failure(it)) }
+  val sessionDetailState: StateFlow<Lce<SessionDetailState>> = sessionsRepository.getSession(sessionId)
+    .transformLatest { sessionResult ->
+      sessionResult
+        .onSuccess { session ->
+          combine(
+            roomsRepository.getRoom(session.roomId),
+            speakersRepository.getSpeakers(session.speakers),
+            bookmarksRepository.isBookmarked(sessionId)
+          ) { roomResult, speakersResult, isBookmarked ->
+            val room = roomResult.getOrElse { return@combine Lce.Error }
+            val speakers = speakersResult.getOrElse { return@combine Lce.Error }
+            Lce.Content(
+              SessionDetailState(
+                session = session,
+                room = room,
+                speakers = speakers,
+                startTimestamp = session.startsAt.toInstant(TimeZone.currentSystemDefault()),
+                endTimestamp = session.endsAt.toInstant(TimeZone.currentSystemDefault()),
+                isBookmarked = isBookmarked,
+              )
+            )
+          }.collect(this)
+        }
+        .onFailure {
+          emit(Lce.Error)
+        }
+    }.stateIn(
+      scope = viewModelScope,
+      started = SharingStarted.Eagerly,
+      initialValue = Lce.Loading
     )
-  }
-
-  private val speakers: Flow<List<Speaker>> = session.mapNotNull { result ->
-    result.getOrNull()?.speakers?.let { speakerIds ->
-      speakersRepository.getSpeakers(speakerIds).first().getOrNull()
-    }
-  }
-
-  private val formattedDateAndRoom: Flow<String> =
-    combine(session, room) { sessionResult, roomResult ->
-      sessionResult.fold(
-        onSuccess = {
-          val sessionDate = formatTimeInterval(
-            it.startsAt,
-            it.endsAt
-          )
-          val roomName = roomResult.getOrNull()?.name
-          if (!roomName.isNullOrEmpty()) {
-            "$sessionDate, $roomName"
-          } else {
-            sessionDate
-          }
-        },
-        onFailure = { "" }
-      )
-    }
-
-  val sessionDetailState: Flow<Lce<SessionDetailState>> = combine(
-    session,
-    room,
-    bookmarksRepository.isBookmarked(sessionId),
-  ) { sessionResult, roomResult, isBookmarked ->
-
-    val session = sessionResult.getOrElse {
-      return@combine Lce.Error
-    }
-    val room = roomResult.getOrElse {
-      return@combine Lce.Error
-    }
-    Lce.Content(
-      SessionDetailState(
-        session = session,
-        room = room,
-        speakers = speakers.first(),
-        startTimestamp = session.startsAt.toInstant(TimeZone.currentSystemDefault()),
-        endTimestamp = session.endsAt.toInstant(TimeZone.currentSystemDefault()),
-        isBookmarked = isBookmarked,
-      )
-    )
-  }
 
   fun bookmark(bookmarked: Boolean) = viewModelScope.launch {
-    session.first().onSuccess {
-      setSessionBookmarkUseCase(it.id, bookmarked)
+    val lce = sessionDetailState.first { it !is Lce.Loading }
+    if (lce is Lce.Content) {
+      setSessionBookmarkUseCase(lce.content.session.id, bookmarked)
     }
   }
 
   fun shareSession(platformContext: PlatformContext) = viewModelScope.launch {
-    session.first().onSuccess {
-      shareSessionUseCase(platformContext, it, speakers.first(), formattedDateAndRoom.first())
+    val lce = sessionDetailState.first { it !is Lce.Loading }
+    if (lce is Lce.Content) {
+      val state = lce.content
+      shareSessionUseCase(
+        platformContext = platformContext,
+        session = state.session,
+        speakers = state.speakers,
+        formattedDateAndRoom = state.formattedDateAndRoom
+      )
     }
   }
 

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailViewModel.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailViewModel.kt
@@ -51,8 +51,8 @@ class SessionDetailViewModel(
   }
 
   private val speakers: Flow<List<Speaker>> = session.mapNotNull { result ->
-    result.getOrNull()?.speakers?.mapNotNull {
-      speakersRepository.getSpeaker(it).first().getOrNull()
+    result.getOrNull()?.speakers?.let { speakerIds ->
+      speakersRepository.getSpeakers(speakerIds).first().getOrNull()
     }
   }
 

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/model/Lce.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/model/Lce.kt
@@ -2,7 +2,7 @@ package com.androidmakers.ui.model
 
 sealed interface Lce<out T> {
   data object Loading : Lce<Nothing>
-  class Content<T>(val content: T) : Lce<T>
+  data class Content<T>(val content: T) : Lce<T>
   data object Error : Lce<Nothing>
 }
 

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/model/SessionDetailState.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/model/SessionDetailState.kt
@@ -16,15 +16,16 @@ class SessionDetailState(
     val endTimestamp: Instant,
     val isBookmarked: Boolean,
 ) {
-    fun formattedDateAndRoom(): String {
-        val formattedDate = formatTimeInterval(
-            startTimestamp.toLocalDateTime(TimeZone.currentSystemDefault()),
-            endTimestamp.toLocalDateTime(TimeZone.currentSystemDefault())
-        )
-        return if (room.name.isNotEmpty()) {
-            "$formattedDate, ${room.name}"
-        } else {
-            formattedDate
+    val formattedDateAndRoom: String
+        get() {
+            val formattedDate = formatTimeInterval(
+                startTimestamp.toLocalDateTime(TimeZone.currentSystemDefault()),
+                endTimestamp.toLocalDateTime(TimeZone.currentSystemDefault())
+            )
+            return if (room.name.isNotEmpty()) {
+                "$formattedDate, ${room.name}"
+            } else {
+                formattedDate
+            }
         }
-    }
 }


### PR DESCRIPTION
- Load all data from a single main Flow instead of collecting the same source Flow multiple times to load the different parts of the session
- Cache the results in a `StateFlow`
- Query `SpeakersRepository` once per session to load all speakers at once.