### PR TITLE
refactor: improve Edge-to-edge implementation

### DIFF
--- a/androidApp/src/main/res/values-night/themes.xml
+++ b/androidApp/src/main/res/values-night/themes.xml
@@ -3,6 +3,8 @@
 
     <style name="Theme.AndroidMakers" parent="android:Theme.Material.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowBackground">@color/backgroundDark</item>
     </style>
 

--- a/androidApp/src/main/res/values/themes.xml
+++ b/androidApp/src/main/res/values/themes.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Theme.AndroidMakers" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
         <item name="android:windowBackground">@color/backgroundLight</item>
     </style>
 

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/AgendaLayout.kt
@@ -3,7 +3,6 @@ package com.androidmakers.ui.agenda
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -62,7 +61,6 @@ fun AgendaLayout(
             drawerContainerColor = MaterialTheme.colorScheme.surface,
             drawerContentColor = MaterialTheme.colorScheme.onSurface,
             drawerShape = RectangleShape,
-            windowInsets = WindowInsets(0, 0, 0, 0),
         ) {
           AgendaFilterDrawer(
               rooms = rooms,

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailLayout.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -156,13 +157,19 @@ fun SessionDetailLayout(
   ) { innerPadding ->
     Box {
       when (sessionDetailState) {
-        is Lce.Loading, Lce.Error -> LoadingLayout()
+        is Lce.Loading, Lce.Error -> LoadingLayout(
+          modifier = Modifier
+            .padding(innerPadding)
+            .consumeWindowInsets(innerPadding)
+        )
         is Lce.Content -> SessionDetails(
           sessionDetails = sessionDetailState.content,
           formattedDateAndRoom = sessionDetailState.content.formattedDateAndRoom,
           openLink = onOpenLink,
           onApplyForAppClinic = onApplyForAppClinic,
-          modifier = Modifier.padding(innerPadding)
+          modifier = Modifier
+            .padding(innerPadding)
+            .consumeWindowInsets(innerPadding)
         )
       }
     }

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailLayout.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -47,6 +48,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -106,7 +108,9 @@ fun SessionDetailLayout(
   onOpenLink: (SocialsItem) -> Unit,
   onApplyForAppClinic: () -> Unit,
 ) {
+  val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
   Scaffold(
+    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
     topBar = {
       TopAppBar(
         navigationIcon = {
@@ -131,7 +135,8 @@ fun SessionDetailLayout(
               )
             }
           }
-        }
+        },
+        scrollBehavior = scrollBehavior
       )
     },
     floatingActionButton = {

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/LceLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/LceLayout.kt
@@ -18,9 +18,11 @@ import dev.icerock.moko.resources.compose.stringResource
 import fr.paug.androidmakers.ui.MR
 
 @Composable
-fun LoadingLayout() {
+fun LoadingLayout(
+  modifier: Modifier = Modifier
+) {
   Box(
-      modifier = Modifier.fillMaxSize(),
+      modifier = modifier.fillMaxSize(),
       contentAlignment = Alignment.Center
   ) {
     CircularProgressIndicator()

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/AVALayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/AVALayout.kt
@@ -92,10 +92,8 @@ fun AVALayout(
         TopAppBar(
             scrollBehavior = scrollBehavior,
             colors = TopAppBarDefaults.topAppBarColors(
-                containerColor = MaterialTheme.colorScheme.background,
-                scrolledContainerColor = MaterialTheme.colorScheme.background,
-                titleContentColor = MaterialTheme.colorScheme.onBackground,
-                actionIconContentColor = MaterialTheme.colorScheme.onBackground,
+                scrolledContainerColor = MaterialTheme.colorScheme.surface,
+                actionIconContentColor = MaterialTheme.colorScheme.onSurface,
             ),
             navigationIcon = {
               Box(modifier = Modifier.padding(14.dp)) {

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/AVALayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/AVALayout.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -186,7 +187,10 @@ fun AVALayout(
         }
       },
   ) { innerPadding ->
-    Box(Modifier.padding(innerPadding)) {
+    Box(
+      Modifier.padding(innerPadding)
+        .consumeWindowInsets(innerPadding)
+    ) {
       AVANavHost(
           versionCode = versionCode,
           versionName = versionName,

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/AVALayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/common/navigation/AVALayout.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -88,7 +87,6 @@ fun AVALayout(
 
   Scaffold(
       modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-      contentWindowInsets = WindowInsets(0, 0, 0, 0),
       topBar = {
         TopAppBar(
             scrollBehavior = scrollBehavior,

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailsScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailsScreen.kt
@@ -2,6 +2,7 @@ package com.androidmakers.ui.speakers
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -85,8 +86,9 @@ fun SpeakerDetailsScreen(
     Column(
         modifier = Modifier
           .verticalScroll(rememberScrollState())
-            .padding(innerPadding)
-            .padding(16.dp),
+          .padding(innerPadding)
+          .consumeWindowInsets(innerPadding)
+          .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
     ) {
 

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailsScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailsScreen.kt
@@ -17,12 +17,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -66,7 +68,9 @@ fun SpeakerDetailsScreen(
     onBackClick: () -> Unit,
 ) {
   val speaker = uiState.speaker
+  val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
   Scaffold(
+      modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
       topBar = {
         TopAppBar(
             navigationIcon = {
@@ -79,7 +83,8 @@ fun SpeakerDetailsScreen(
             },
             title = {
               // Nothing to do
-            }
+            },
+            scrollBehavior = scrollBehavior
         )
       }
   ) { innerPadding ->

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerListScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerListScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -132,8 +131,7 @@ fun SpeakerScreen(
             },
           colors = SearchBarDefaults.colors(
             dividerColor = MaterialTheme.colorScheme.primary
-          ),
-          windowInsets = WindowInsets(0.dp, 0.dp, 0.dp, 0.dp)
+          )
         ) {
           LazyColumn {
             items(


### PR DESCRIPTION
- Make the Android app theme blend smoothly from the "splash" screen to the content
- Consume Window insets early in `AVALayout` so they don't have to be overridden in child layouts
- Change the app bar color during scroll in detail screens.