### PR TITLE
refactor: remove unnecessary expect/actual classes

### DIFF
--- a/shared/di/src/androidMain/kotlin/fr/androidmakers/di/DomainModule.android.kt
+++ b/shared/di/src/androidMain/kotlin/fr/androidmakers/di/DomainModule.android.kt
@@ -1,11 +1,12 @@
 package fr.androidmakers.di
 
+import fr.androidmakers.domain.interactor.AndroidOpenMapUseCase
+import fr.androidmakers.domain.interactor.AndroidShareSessionUseCase
 import fr.androidmakers.domain.interactor.OpenMapUseCase
 import fr.androidmakers.domain.interactor.ShareSessionUseCase
-import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
 actual val domainPlatformModule = module {
-  factoryOf(::OpenMapUseCase)
-  factoryOf(::ShareSessionUseCase)
+  factory<OpenMapUseCase> { AndroidOpenMapUseCase() }
+  factory<ShareSessionUseCase> { AndroidShareSessionUseCase() }
 }

--- a/shared/di/src/androidMain/kotlin/fr/androidmakers/di/Inject.android.kt
+++ b/shared/di/src/androidMain/kotlin/fr/androidmakers/di/Inject.android.kt
@@ -8,8 +8,8 @@ import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
 import org.koin.core.module.Module
 
-actual class DependenciesBuilder(private val context: Context) {
-  actual fun inject(platformModules: List<Module>) {
+class DependenciesBuilder(private val context: Context) {
+  fun inject(platformModules: List<Module>) {
     startKoin {
       if (BuildConfig.DEBUG) {
         androidLogger(Level.DEBUG)

--- a/shared/di/src/commonMain/kotlin/fr/androidmakers/di/Inject.kt
+++ b/shared/di/src/commonMain/kotlin/fr/androidmakers/di/Inject.kt
@@ -1,11 +1,5 @@
 package fr.androidmakers.di
 
-import org.koin.core.module.Module
-
-expect class DependenciesBuilder {
-  fun inject(platformModules: List<Module>)
-}
-
 val sharedModules = listOf(
     dataModule,
     domainModule,

--- a/shared/di/src/iosMain/kotlin/fr/androidmakers/di/DomainModule.ios.kt
+++ b/shared/di/src/iosMain/kotlin/fr/androidmakers/di/DomainModule.ios.kt
@@ -1,11 +1,12 @@
 package fr.androidmakers.di
 
+import fr.androidmakers.domain.interactor.IosOpenMapUseCase
+import fr.androidmakers.domain.interactor.IosShareSessionUseCase
 import fr.androidmakers.domain.interactor.OpenMapUseCase
 import fr.androidmakers.domain.interactor.ShareSessionUseCase
-import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
 actual val domainPlatformModule = module {
-  factoryOf(::OpenMapUseCase)
-  factoryOf(::ShareSessionUseCase)
+  factory<OpenMapUseCase> { IosOpenMapUseCase() }
+  factory<ShareSessionUseCase> { IosShareSessionUseCase() }
 }

--- a/shared/di/src/iosMain/kotlin/fr/androidmakers/di/Inject.ios.kt
+++ b/shared/di/src/iosMain/kotlin/fr/androidmakers/di/Inject.ios.kt
@@ -3,8 +3,8 @@ package fr.androidmakers.di
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 
-actual class DependenciesBuilder {
-  actual fun inject(platformModules: List<Module>) {
+class DependenciesBuilder {
+  fun inject(platformModules: List<Module>) {
     startKoin {
       modules(
           platformModules +

--- a/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/interactor/OpenMapUseCase.android.kt
+++ b/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/interactor/OpenMapUseCase.android.kt
@@ -6,8 +6,8 @@ import android.content.Intent
 import android.net.Uri
 import androidx.core.net.toUri
 
-actual class OpenMapUseCase() {
-  actual operator fun invoke(context: Context, coordinates: String, name: String) {
+class AndroidOpenMapUseCase : OpenMapUseCase {
+  override operator fun invoke(context: Context, coordinates: String, name: String) {
     val venueCoordinatesUri = Uri.Builder()
       .scheme("geo")
       .encodedAuthority(coordinates)

--- a/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/interactor/ShareSessionUseCase.android.kt
+++ b/shared/domain/src/androidMain/kotlin/fr/androidmakers/domain/interactor/ShareSessionUseCase.android.kt
@@ -5,8 +5,8 @@ import androidx.core.app.ShareCompat
 import fr.androidmakers.domain.model.Session
 import fr.androidmakers.domain.model.Speaker
 
-actual class ShareSessionUseCase {
-  actual operator fun invoke(
+class AndroidShareSessionUseCase : ShareSessionUseCase {
+  override operator fun invoke(
     context: Context,
     session: Session,
     speakers: List<Speaker>,

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/OpenMapUseCase.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/OpenMapUseCase.kt
@@ -2,6 +2,6 @@ package fr.androidmakers.domain.interactor
 
 import fr.androidmakers.domain.PlatformContext
 
-expect class OpenMapUseCase {
+interface OpenMapUseCase {
   operator fun invoke(context: PlatformContext, coordinates: String, name: String)
 }

--- a/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/ShareSessionUseCase.kt
+++ b/shared/domain/src/commonMain/kotlin/fr/androidmakers/domain/interactor/ShareSessionUseCase.kt
@@ -5,7 +5,7 @@ import fr.androidmakers.domain.model.Session
 import fr.androidmakers.domain.model.Speaker
 
 // TODO to be improved
-expect class ShareSessionUseCase {
+interface ShareSessionUseCase {
   operator fun invoke(
     context: PlatformContext,
     session: Session,

--- a/shared/domain/src/iosMain/kotlin/fr/androidmakers/domain/interactor/OpenMapUseCase.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/fr/androidmakers/domain/interactor/OpenMapUseCase.ios.kt
@@ -6,9 +6,9 @@ import platform.CoreLocation.CLLocationCoordinate2DMake
 import platform.MapKit.MKMapItem
 import platform.MapKit.MKPlacemark
 
-actual class OpenMapUseCase {
+class IosOpenMapUseCase : OpenMapUseCase {
   @OptIn(ExperimentalForeignApi::class)
-  actual operator fun invoke(context: PlatformContext, coordinates: String, name: String) {
+  override operator fun invoke(context: PlatformContext, coordinates: String, name: String) {
     val coordinateArray = coordinates.split(",")
     if (coordinateArray.size == 2) {
       val latitude = coordinateArray[0].toDoubleOrNull()

--- a/shared/domain/src/iosMain/kotlin/fr/androidmakers/domain/interactor/ShareSessionUseCase.ios.kt
+++ b/shared/domain/src/iosMain/kotlin/fr/androidmakers/domain/interactor/ShareSessionUseCase.ios.kt
@@ -8,8 +8,8 @@ import platform.Foundation.stringWithFormat
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
 
-actual class ShareSessionUseCase {
-  actual operator fun invoke(
+class IosShareSessionUseCase : ShareSessionUseCase {
+  override operator fun invoke(
     context: PlatformContext,
     session: Session,
     speakers: List<Speaker>,


### PR DESCRIPTION
Expect/Actual classes are in Beta and should be avoided whenever possible, as recommended in the [official Kotlin documentation](https://kotlinlang.org/docs/multiplatform-expect-actual.html#expected-and-actual-classes).
Use interfaces in place of expect classes, or nothing if the class is not referenced from common code.