### PR TITLE
Make some text items selectable.

### DIFF
--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailLayout.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/agenda/SessionDetailLayout.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -204,6 +205,7 @@ private fun SessionDetails(
   onApplyForAppClinic: () -> Unit,
 ) {
 
+
   Column(
     Modifier
       .verticalScroll(state = rememberScrollState())
@@ -211,10 +213,12 @@ private fun SessionDetails(
       .then(modifier)
   ) {
 
-    Text(
-      text = sessionDetails.session.title,
-      style = MaterialTheme.typography.headlineLarge
-    )
+    SelectionContainer {
+      Text(
+        text = sessionDetails.session.title,
+        style = MaterialTheme.typography.headlineLarge
+      )
+    }
 
     Row(
       modifier = Modifier.padding(top = 16.dp),
@@ -233,12 +237,14 @@ private fun SessionDetails(
       )
     }
 
-    Text(
-      modifier = Modifier.padding(top = 16.dp),
-      text = sessionDetails.session.description.orEmpty(),
-      textAlign = TextAlign.Start,
-      style = MaterialTheme.typography.bodyLarge,
-    )
+    SelectionContainer {
+      Text(
+        modifier = Modifier.padding(top = 16.dp),
+        text = sessionDetails.session.description.orEmpty(),
+        textAlign = TextAlign.Start,
+        style = MaterialTheme.typography.bodyLarge,
+      )
+    }
 
     if(sessionDetails.session.isAppClinic()) {
       Button(
@@ -385,18 +391,22 @@ private fun Speaker(
       )
     }
 
-    Text(
-      text = speaker.getFullNameAndCompany(),
-      style = MaterialTheme.typography.titleLarge,
-    )
+    SelectionContainer {
+      Text(
+        text = speaker.getFullNameAndCompany(),
+        style = MaterialTheme.typography.titleLarge,
+      )
+    }
 
     speaker.bio?.let { bio ->
-      Text(
-        modifier = Modifier.padding(),
-        text = bio,
-        textAlign = TextAlign.Start,
-        style = MaterialTheme.typography.bodyMedium,
-      )
+      SelectionContainer {
+        Text(
+          modifier = Modifier.padding(),
+          text = bio,
+          textAlign = TextAlign.Start,
+          style = MaterialTheme.typography.bodyMedium,
+        )
+      }
     }
 
     SocialButtons(

--- a/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailsScreen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/androidmakers/ui/speakers/SpeakerDetailsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -110,16 +111,20 @@ fun SpeakerDetailsScreen(
         )
       }
 
-      Text(
-          text = speaker.name.orEmpty(),
-          style = MaterialTheme.typography.headlineLarge
-      )
+      SelectionContainer {
+        Text(
+            text = speaker.name.orEmpty(),
+            style = MaterialTheme.typography.headlineLarge
+        )
+      }
 
-      Text(
-          text = speaker.bio.orEmpty(),
-          textAlign = TextAlign.Start,
-          style = MaterialTheme.typography.bodyLarge,
-      )
+      SelectionContainer {
+        Text(
+            text = speaker.bio.orEmpty(),
+            textAlign = TextAlign.Start,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+      }
 
       SocialButtons(
           speaker = speaker,


### PR DESCRIPTION
Having some of the session and speaker attributes selectable could be useful. For example, I was writing a summary document about the conference, using my phone, and it would have been easier if I could have copied/pasted this information into my document.

So:
Make the following text items selectable:
* Session details:
  - Session title
  - Session description
  - Speaker name
  - Speaker bio
* Speaker details:
  - Speaker name
  - Speaker bio


|Screen|Screenshots (Android 35 emulator)|
|---|---|
|Session details<br>(session section)|<img src="https://github.com/user-attachments/assets/3618540e-9ea4-44fd-8144-e1868a84cdc1" width="240"> <img src="https://github.com/user-attachments/assets/b2f0b5a6-20be-4d0f-b432-689a3c83fef6" width="240">|
|Session details<br>(speaker section)|<img src="https://github.com/user-attachments/assets/3b765678-fb13-4407-ab92-1396b1368ad6" width="240"> <img src="https://github.com/user-attachments/assets/2e4d21e1-3988-4bdf-b79a-7cb21ab49ae1" width="240">|
|Speaker details|<img src="https://github.com/user-attachments/assets/d800646a-ee3f-4724-b931-2e74060316dc" width="240"> <img src="https://github.com/user-attachments/assets/9d443cf3-2fc0-4084-af3c-408976448dcd" width="240">|
